### PR TITLE
Cytoscape test - DO NOT MERGE

### DIFF
--- a/root/templates/shared/widgets/interactions.tt2
+++ b/root/templates/shared/widgets/interactions.tt2
@@ -1,7 +1,19 @@
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="js/jquery-1.9.1.min.js"><\/script>')</script>
 
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.1/jquery-ui.min.js"></script>
+    <script>window.jQuery.ui || document.write('<script src="js/jquery-ui-1.10.1.custom.min.js"><\/script>')</script>
+
+    <script src="/js/wormbase[% c.config.installation_type == 'development' ? '' : '.min' %].js?v[% git_commit_id %]"></script>
+    <script>
+      window.WB || document.write('<script src="/js/wormbase.js"><\/script>');
+      [% INCLUDE google_analytics %]
+    </script>
 
 
 [%
+
+
   MACRO interaction_table BLOCK;
   WRAPPER $field_block title="Interactions" key="interactions";
       'Found ';


### PR DESCRIPTION
This PR is just to show that Cytoscape still does the weird disappearing thing when loaded separately.

Page for testing:
/rest/widget/gene/WBGene00006763/interactions
-- this is the url to go to a widget directly. It usually just contains the HTML of the widget, but I added the JS so cytoscape would load.

Add js to interactions widget so cytoscape will load when looking at a widget directly (not on a page)
- test for #2957

This tells us that:
- The problem is not conflicts with other widgets or CSS
- The problem _could_ be our JS
