### PR TITLE
Sequence refactor

### DIFF
--- a/lib/WormBase/API/Object/Cds.pm
+++ b/lib/WormBase/API/Object/Cds.pm
@@ -355,7 +355,7 @@ sub _build__segments {
 
 
 sub _print_unspliced {
-    my ($markup,$seq_obj,$unspliced,@features) = @_;
+    my ($self,$seq_obj,$unspliced,@features) = @_;
     my $name = $seq_obj->info . ' (' . $seq_obj->start . '-' . $seq_obj->stop . ')';
 
     my $length   = length $unspliced;
@@ -377,7 +377,7 @@ sub _print_unspliced {
         push @markup,map {['space',10*$_]}   (1..length($unspliced)/10);
         push @markup,map {['newline',80*$_]} (1..length($unspliced)/80);
 #       my $download = _to_fasta("$name|unspliced + UTR - $length bp",$unspliced);
-        $markup->markup(\$unspliced,\@markup);
+        $self->markup_scheme->markup(\$unspliced,\@markup);
         return {
             #download => $download,
             header=>"unspliced + UTR",
@@ -392,7 +392,7 @@ sub _print_unspliced {
 # Fetch and markup the spliced DNA
 # markup alternative exons
 sub _print_spliced {
-    my ($markup,@features) = @_;
+    my ($self, @features) = @_;
     my $spliced = join('',map {$_->dna} @features);
     my $splen   = length $spliced;
     my $last    = 0;
@@ -401,6 +401,7 @@ sub _print_spliced {
     my $prefasta = $spliced;
     for my $feature (@features) {
         my $length = $feature->stop - $feature->start + 1;
+print "length!! $length\n";
         my $style  = $feature->method =~ /UTR/i ? 'utr' : 'cds' . $counter++ %2;
         my $end = $last + $length;
         push @markup,[$style,$last,$end];
@@ -412,7 +413,7 @@ sub _print_spliced {
     push @markup,map {['newline',80*$_]} (1..length($spliced)/80);
     my $name = eval { $features[0]->refseq->name } ;
 #   my $download=_to_fasta("$name|spliced + UTR - $splen bp",$spliced);
-    $markup->markup(\$spliced,\@markup);
+    $self->markup_scheme->markup(\$spliced,\@markup);
 
     return {                    # download => $download ,
         header=>"spliced + UTR",
@@ -424,7 +425,7 @@ sub _print_spliced {
 }
 
 sub _print_protein {
-    my ($markup,$features,$genetic_code) = @_;
+    my ($self,$features,$genetic_code) = @_;
 #   my @markup;
     my $trimmed = join('',map {$_->dna} grep {$_->method eq 'coding_exon'} @$features);
     return unless $trimmed;     # Hack for mRNA
@@ -502,4 +503,3 @@ sub _get_parent_coords {
 __PACKAGE__->meta->make_immutable;
 
 1;
-

--- a/lib/WormBase/API/Object/Cds.pm
+++ b/lib/WormBase/API/Object/Cds.pm
@@ -367,6 +367,34 @@ around '_print_spliced' => sub {
 
 };
 
+
+# get coordinates of parent for exons etc
+# I don't see any difference between this and what's in Role::Sequence
+# Will remove when test case is written
+sub _get_parent_coords {
+    my ($self,$s) = @_;
+    my ($parent) = $self->sequence;
+    return unless $parent;
+    #  my $subseq = $parent->get('Subsequence');  # prevent automatic dereferencing
+
+    # Escape the sequence name for fetching
+    $s =~ s/\./\\./g;
+    # We may be dealing with transcripts, too.
+    my $se;
+    foreach my $tag (qw/CDS_child Transcript/) {
+        my $subseq = $parent->get($tag); # prevent automatic dereferencing
+        if ($subseq) {
+            $se = $subseq->at($s);
+            if ($se) {
+                my ($start,$stop) = $se->right->row;
+                my $orientation = $start <=> $stop;
+                return ($start,-$orientation,$parent);
+            }
+        }
+    }
+    return;
+}
+
 # sub _print_protein {
 # ...
 #     my $trimmed = join('',map {$_->dna} grep {$_->method eq 'coding_exon'} @$features);

--- a/lib/WormBase/API/Role/Sequence.pm
+++ b/lib/WormBase/API/Role/Sequence.pm
@@ -40,6 +40,31 @@ has 'genes' => (
     },
    );
 
+
+# the corresponding sequence object got from GFF database
+has 'seq_obj' =>  (
+    is  => 'ro',
+    lazy => 1,
+    isa => 'Maybe[Object]',
+    builder => '_build__seq_obj'
+);
+
+our $_markup_scheme = Bio::Graphics::Browser2::Markup->new;
+$_markup_scheme->add_style('utr'  => 'FGCOLOR gray');
+$_markup_scheme->add_style('cds'  => 'BGCOLOR cyan');
+$_markup_scheme->add_style('cds0' => 'BGCOLOR yellow');
+$_markup_scheme->add_style('cds1' => 'BGCOLOR orange');
+$_markup_scheme->add_style('uc'   => 'UPPERCASE');
+$_markup_scheme->add_style('newline' => "\n");
+$_markup_scheme->add_style('space'   => '');
+
+has 'markup_scheme' => (
+    is  => 'ro',
+    lazy => 1,
+    default => sub {
+        $_markup_scheme;
+    }
+);
 #######################################################
 #
 # Generic methods, shared across Sequence, CDS, and Transcript classes.
@@ -914,23 +939,8 @@ sub print_sequence {
     my ($self) = @_;
     my $s = $self->object;
     my @data;
-    my $gff = $self->gff || goto END;
-    my $seq_obj;
 
-    # Genomic clones need to be fetched a bit differently.
-    unless ($s->class =~ /Sequence|Clone/i) {
-        ($seq_obj) = sort {$b->length<=>$a->length}
-                        grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name($s);
-
-        # BLECH!  If provided with a gene ID and alt splices are present just guess
-        # and fetch the first CDS or Transcript
-        # We really should display a list for all of these.
-
-        ($seq_obj) = $seq_obj ? ($seq_obj) : sort {$b->length<=>$a->length}
-                grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name("$s.a");
-        ($seq_obj) = $seq_obj ? ($seq_obj) : sort {$b->length<=>$a->length}
-                grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name("$s.1");
-    }
+    my $seq_obj = $self->seq_obj;  # try the GFF first
 
     # Haven't fetched a GFF segment? Try Ace.
     # miserable broken workaround
@@ -955,30 +965,17 @@ sub print_sequence {
 
     my $unspliced = lc $seq_obj->dna;
     my $length = length($unspliced);
+
     if (eval { $s->Coding_pseudogene } || eval {$s->Coding} || eval {$s->Corresponding_CDS}) {
-        my $markup = Bio::Graphics::Browser2::Markup->new;
-        $markup->add_style('utr'  => 'FGCOLOR gray');
-        $markup->add_style('cds'  => 'BGCOLOR cyan');
-        $markup->add_style('cds0' => 'BGCOLOR yellow');
-        $markup->add_style('cds1' => 'BGCOLOR orange');
-        $markup->add_style('uc'   => 'UPPERCASE');
-        $markup->add_style('newline' => "\n");
-        $markup->add_style('space'   => '');
-        my %seenit;
 
         # local coordinates
         $seq_obj->ref($seq_obj);
 
-        # sort by stop if on -ve strand
-        my @features = grep { $_->primary_tag ne 'intron' && $_->primary_tag ne 'exon'}
-            map { $_->primary_tag eq 'CDS' ? ($_->get_SeqFeatures) : ($_) }
-            $seq_obj->get_SeqFeatures();
+        my @features = $self->_get_ordered_features($seq_obj);
 
-        @features = ($seq_obj->strand > 0) ? sort { $a->start <=> $b->start } @features : sort { $b->stop <=> $a->stop } @features;
-
-        push @data, _print_unspliced($markup,$seq_obj,$unspliced,@features);
-        push @data, _print_spliced($markup,@features);
-        push @data, _print_protein($markup,\@features) unless eval { $s->Coding_pseudogene };
+        push @data, $self->_print_unspliced($seq_obj,$unspliced,@features);
+        push @data, $self->_print_spliced(@features);
+        push @data, $self->_print_protein(\@features) unless eval { $s->Coding_pseudogene };
     } else {
         # Otherwise we've got genomic DNA here
         push @data, {
@@ -993,6 +990,57 @@ sub print_sequence {
     return { description => 'the sequence of the sequence',
              data        => @data ? \@data : undef };
 }
+
+
+sub _build__seq_obj {
+    my ($self) = @_;
+    return unless $self->gff;
+
+    my $gff = $self->gff;
+    my $s = $self->object;
+    my $seq_obj;
+
+    # Genomic clones need to be fetched a bit differently.
+    unless ($s->class =~ /Sequence|Clone/i) {
+        ($seq_obj) = sort {$b->length<=>$a->length}
+                        grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name($s);
+
+        # BLECH!  If provided with a gene ID and alt splices are present just guess
+        # and fetch the first CDS or Transcript
+        # We really should display a list for all of these.
+
+        ($seq_obj) = $seq_obj ? ($seq_obj) : sort {$b->length<=>$a->length}
+                grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name("$s.a");
+        ($seq_obj) = $seq_obj ? ($seq_obj) : sort {$b->length<=>$a->length}
+                grep {$_->primary_tag eq 'mRNA'} $gff->get_features_by_name("$s.1");
+    #    $seq_obj->{'start'} = '13261546';
+     #   $seq_obj->{'stop'} = '13272524';
+    }
+    return $seq_obj;
+
+}
+
+sub _get_ordered_features {
+    my ($self, $seq_obj) = @_;
+    # sort by stop if on -ve strand
+    my @features = grep { $_->primary_tag ne 'intron' && $_->primary_tag ne 'exon'}
+        map { $_->primary_tag eq 'CDS' ? ($_->get_SeqFeatures) : ($_) }
+            $seq_obj->get_SeqFeatures();
+
+    @features = ($seq_obj->strand > 0) ? sort { $a->start <=> $b->start } @features : sort { $b->stop <=> $a->stop } @features;
+
+    return @features;
+}
+
+sub print_extend_sequence {
+    my ($self, $args) = @_;
+    my $num_upstream = $args->{'upstream'};
+    my $num_downstream = $args->{'downstream'};
+
+    print Dumper $args;
+
+}
+
 
 =head3 print_homologies
 
@@ -1486,7 +1534,8 @@ sub _build__segments {
 }
 
 sub _print_unspliced {
-    my ($markup,$seq_obj,$unspliced,@features) = @_;
+    my ($self, $seq_obj,$unspliced, @features) = @_;
+print Dumper $seq_obj;
     my $name = $seq_obj . ' (' . $seq_obj->start . '-' . $seq_obj->stop . ')';
     my $length_all   = length $unspliced;
     if ($length_all > 0) {
@@ -1506,7 +1555,7 @@ sub _print_unspliced {
         }
         push @markup,map {['space',10*$_]}   (1..length($unspliced)/10);
         push @markup,map {['newline',80*$_]} (1..length($unspliced)/80);
-        $markup->markup(\$unspliced,\@markup);
+        $self->markup_scheme->markup(\$unspliced,\@markup);
         return {
             header=>"unspliced + UTR",
             sequence=>$unspliced,
@@ -1519,7 +1568,7 @@ sub _print_unspliced {
 # Fetch and markup the spliced DNA
 # markup alternative exons
 sub _print_spliced {
-    my ($markup,@features) = @_;
+    my ($self, @features) = @_;
     my $spliced = join('',map {$_->dna} @features);
     my $splen   = length $spliced;
     my $last    = 0;
@@ -1538,7 +1587,7 @@ sub _print_spliced {
 
     push @markup,map {['space',10*$_]}   (1..length($spliced)/10);
     push @markup,map {['newline',80*$_]} (1..length($spliced)/80);
-    $markup->markup(\$spliced,\@markup);
+    $self->markup_scheme->markup(\$spliced,\@markup);
     return {
         header=>"spliced + UTR",
         sequence=>$spliced,
@@ -1549,7 +1598,7 @@ sub _print_spliced {
 }
 
 sub _print_protein {
-    my ($markup,$features,$genetic_code) = @_;
+    my ($self,$features,$genetic_code) = @_;
 #   my @markup;
     my $trimmed = join('',map {$_->dna} grep {$_->primary_tag eq 'CDS'} @$features);
     return unless $trimmed;     # Hack for mRNA

--- a/lib/WormBase/API/Role/Sequence.pm
+++ b/lib/WormBase/API/Role/Sequence.pm
@@ -946,9 +946,8 @@ sub print_sequence {
     # Haven't fetched a GFF segment? Try Ace.
     # miserable broken workaround
     if (!$seq_obj || eval{ length($seq_obj->dna) } < 2 || eval { $s->Properties eq 'cDNA'}) {
-# why cDNA is special? that we can't get from cDNA?
+# why cDNA is special? that we can't get from GFF if available?
 
-        # try to use acedb
         my $fasta = $s->asDNA || '';
         $fasta =~ s/^\s?>(.*)\n//;
         $fasta =~ s/\s//g;

--- a/lib/WormBase/API/Role/Sequence.pm
+++ b/lib/WormBase/API/Role/Sequence.pm
@@ -939,54 +939,59 @@ sub print_sequence {
     my ($self) = @_;
     my $s = $self->object;
     my @data;
+    my $length;
 
     my $seq_obj = $self->seq_obj;  # try the GFF first
 
     # Haven't fetched a GFF segment? Try Ace.
     # miserable broken workaround
     if (!$seq_obj || eval{ length($seq_obj->dna) } < 2 || eval { $s->Properties eq 'cDNA'}) {
+# why cDNA is special? that we can't get from cDNA?
+
         # try to use acedb
-        if (my $fasta = $s->asDNA) {
-            $fasta =~ s/^\s?>(.*)\n//;
-            $fasta =~ s/\s//g;
-            my $len = length($fasta);
-            if($len > 0){
-                push @data,{
-                    header=>"Sequence",
-                    sequence=>$fasta && "$fasta",
-                    length=>$len,
-                };
-            }
+        my $fasta = $s->asDNA || '';
+        $fasta =~ s/^\s?>(.*)\n//;
+        $fasta =~ s/\s//g;
+        $length = length($fasta);
+
+        if($length){
+            push @data,{
+                header=>"Sequence",
+                sequence=>$fasta && "$fasta",
+                length=>$length,
+            };
         } else {
             push @data, "Sequence unavailable.  If this is a cDNA, try searching for $s.5 or $s.3";
         }
-        goto END;
-    }
 
-    my $unspliced = lc $seq_obj->dna;
-    my $length = length($unspliced);
-
-    if (eval { $s->Coding_pseudogene } || eval {$s->Coding} || eval {$s->Corresponding_CDS}) {
-
-        # local coordinates
-        $seq_obj->ref($seq_obj);
-
-        my @features = $self->_get_ordered_features($seq_obj);
-
-        push @data, $self->_print_unspliced($seq_obj,$unspliced,@features);
-        push @data, $self->_print_spliced(@features);
-        push @data, $self->_print_protein(\@features) unless eval { $s->Coding_pseudogene };
     } else {
-        # Otherwise we've got genomic DNA here
-        push @data, {
-            header => "Genomic Sequence",
-            sequence => "$unspliced",
-            length => $length,
-        };
+
+        my $unspliced = lc $seq_obj->dna;
+        $length = length($unspliced);
+
+        if (eval { $s->Coding_pseudogene } || eval {$s->Coding} || eval {$s->Corresponding_CDS}) {
+
+            # local coordinates
+            $seq_obj->ref($seq_obj);   #Is this needed?
+
+            my @features = $self->_get_ordered_features($seq_obj);
+
+            push @data, $self->_print_unspliced($seq_obj,$unspliced,@features);
+            push @data, $self->_print_spliced(@features);
+            push @data, $self->_print_protein(\@features) unless eval { $s->Coding_pseudogene };
+
+        } else {
+            # Otherwise we've got genomic DNA here
+            push @data, {
+                header => "Genomic Sequence",
+                sequence => "$unspliced",
+                length => $length,
+            };
+        }
     }
+
     $self->length($length);
 
-    END:
     return { description => 'the sequence of the sequence',
              data        => @data ? \@data : undef };
 }

--- a/lib/WormBase/API/Role/Sequence.pm
+++ b/lib/WormBase/API/Role/Sequence.pm
@@ -1027,11 +1027,25 @@ sub _build__seq_obj {
 
 sub _get_ordered_features {
     my ($self, $seq_obj) = @_;
-    # sort by stop if on -ve strand
-    my @features = grep { $_->primary_tag ne 'intron' && $_->primary_tag ne 'exon'}
-        map { $_->primary_tag eq 'CDS' ? ($_->get_SeqFeatures) : ($_) }
-            $seq_obj->get_SeqFeatures();
 
+    my @features;
+    foreach my $feature ($seq_obj->get_SeqFeatures()) {
+        if ($feature->primary_tag eq 'CDS'){
+            my @cds_segs = $feature->get_SeqFeatures();
+            if (@cds_segs){
+                push @features, @cds_segs
+            } else {
+                # a special case for some single CDS transcript
+                push @features, $feature;
+            }
+        }else{
+            push @features, $feature;
+        }
+    }
+
+    @features = grep { $_->primary_tag ne 'intron' && $_->primary_tag ne 'exon'} @features;
+
+    # sort by stop if on -ve strand
     @features = ($seq_obj->strand > 0) ? sort { $a->start <=> $b->start } @features : sort { $b->stop <=> $a->stop } @features;
 
     return @features;
@@ -1540,7 +1554,7 @@ sub _build__segments {
 
 sub _print_unspliced {
     my ($self, $seq_obj,$unspliced, @features) = @_;
-print Dumper $seq_obj;
+
     my $name = $seq_obj . ' (' . $seq_obj->start . '-' . $seq_obj->stop . ')';
     my $length_all   = length $unspliced;
     if ($length_all > 0) {

--- a/t/api_tests/sequence.t
+++ b/t/api_tests/sequence.t
@@ -35,7 +35,20 @@
         my $seq_pg = $api->fetch({ class => 'Sequence', name => 'yk1352b08.5' });
         isnt($seq_pg->pseudogenes, 'undef', 'pseudogenes data returned');
     }
+
+    sub test_print_sequence {
+        can_ok('WormBase::API::Object::Sequence', 'print_sequence');
+
+        my $seq_obj = $api->fetch({ class => 'Sequence', name => 'AF109378' });
+        my $seq_field = $seq_obj->print_sequence;
+        isnt($seq_field->{'data'}, undef, 'data returned');
+
+        my $full_seq = @{$seq_field->{'data'}}[0];
+        is($full_seq->{'header'}, 'Sequence', 'correct class returned');
+        is($full_seq->{'length'}, '1718', 'correct sequence length returned');
+        is($full_seq->{'sequence'},'ccaaaaatgtcctctgctgctgctgacgaaagtgatgctgtgctcgagaatcttattgcgaaagaaatccttccccaaaccggcaactgggaaggaaccgaggaatttcttaatcgaattgttcaggttcttctgaagtacatcaaagatcagaatgatcgtgatcagaagattctggaattccatcatccagataaaatgcaaatgttgatggatttgtctattccagagaaaccggagagcttgttgaagcttgtgaagagctgtgaagatgtgcttcgattgggtgtacgtactggacatccacgctttttcaaccaaatctcgtgtggactcgacttggtttcgatggctggggaatggcttaccgcaactgcaaatactaatatgttcacctatgaaatcgcgcctgtcttcatccttatggaaaagtcggtaatggccagaatgtgggaagcagttggatgggatccggaaaaagctgatggaatctttgcaccaggtggagcaatcgccaatttgtatgcaatgaatgcggcacgtcatcaactttggccacgtagcaagcatctcggaatgaaggatattccgacattgtgctgctttactagcgaggatagtcactactccatcaaatctgcctccgctgttcttggcattggcgcagactattgcttcaacattccaaccgataaaaatggaaaaatgattccagaagctctagaagctaagattatcgaatgtaaaaaagagggtctgaccccgttctttgcctgctgcacagccggctcaactgtctacggagcatttgatccattggagcgagtcgcaaacatctgtgaacgtcataagctctggttccacgtggatgccgcttggggtggtggaatgctcctgtctcccgagcatcggtacaagctggcaggaattgagagagctaattcagtgacatggaatccacataagctcatgggagcacttctccagtgctcggcatgcttgttccgtcaggatggactactgttccagtgtaatcaaatgtcggctgattatctattccaacaagataaaccgtacgatgtgagctttgatactggagataaagccattcaatgtggacggcacaatgatgttttcaagctttggttgatgtggaagagcaagggaatggagggatatcgtcagcaaattaataagttgatggatttggccaactattttaccaggagaattaaggaaactgaaggatttgagttgattattgagaatcccgaattcctgaacatttgtttctggtacgtgccttcaaagattcgaaacttggagcctgctgaaatgcgtgctcgtttggagaaaattgccccaaaaattaaagccggcatgatgcaaagaggtaccacaatggttggatatcaaccggataagcagcgaccaaatttcttccgaatgattatttcgaatcaggcaatcactcgcgaggacctcgactttctcatcaaggaaattgtggacattggagagtctttggaataattttttcgcgctgcttctgtacctttatattattttgagctccccatatgcttcttagatttgaaaatgttcaagaaaacctgaaacccaaaaagaaatgtatattttatgaaacagtatttaatttatttattgcattatttcatattatataaagattgtagtgaatacgacacttttttata', 'correct sequence returned');
+
+    }
 }
 
 1;
-


### PR DESCRIPTION
Done
- remove duplicate subroutines in Cds.pm - those weren't actually called 
- extract subroutines from print_sequence in Role::Sequence
- attempt to simplify control flow in print_sequence
- Missing markup for CDS in /species/c_elegans/transcript/ZK131.5#05--10

TODO
- add more test case, as I learn the expected outcome for different classes
- Question: The Predicted Exons in the table below Not correspond to the CDS highlighting in the sequence? The exons boundaries listed here is based on data in Ace. Not the GFF. Also these are exons, not cds. Is this okay?
- Question: Do we expect any highlighting for coding pseudogene? 
- Question: what kind of sequence object has `$self->object->Properties eq 'cDNA'`?

Hi @tharris, could you please take do a quick review at the modified print_sequence function? Thanks a lot! https://github.com/WormBase/website/blob/sequence-refactor/lib/WormBase/API/Role/Sequence.pm#L938
