### PR TITLE
Improving rearrangement report page (not ready to pull yet)

### DIFF
--- a/wormbase.conf
+++ b/wormbase.conf
@@ -689,6 +689,10 @@ password_reset_expires = 86400  # 24 hours
         title = Protein
         id    = protein
     </option>
+    <option>
+        title = Rearrangement
+        id    = rearrangement
+    </option>
 #     <option>
 #         title = Sequence
 #         id    = sequence


### PR DESCRIPTION

> We need to make rearrangements more obvious. These are important genetic tools.
Rearrangements should be a search class in the main drop down menu.
 
Added to dropdown in this PR.

> The rearrangment summary should more closely resemble the legacy site: http://legacy.wormbase.org/db/gene/rearrange?name=eDf2;class=Rearrangement; this might require cleaning up the display of the data table which is often times too cramped. (I think we should actually standardize the size of the data table to be full width. Right now it exapnds to fit the size of content which makes all of our tables different widths).

- standardizing table has been done in d3e1136e5236593c30457ad75808321a601e99b3 
- Anything else needs be done in the display of rearrangement?

> Balancers (this are really a form a rearrangement) See https://github.com/WormBase/website/issues/1717 (add to Genome Browser)

Does this need to be shown as a gbrowse image in the location widget of the rearrangement object?
