### PR TITLE
fix tree display for non-WB (web) class ACe class object #2630

### DIFF
--- a/lib/WormBase/API.pm
+++ b/lib/WormBase/API.pm
@@ -245,7 +245,10 @@ sub fetch {
 
             unless ($class) { # an aceclass we don't handle [yet]?
                 $self->log->warn("[API::fetch()]", " ace class $aceclass, UNKNOWN WB class");
-                return 0;
+                return 0 unless $nowrap;
+                # if $nowrap, no WB class object will instantiated,
+                # ok $class eq undef, because it won't be used.
+                # Useful for tree display, which examines ACe objects
             }
         }
 

--- a/lib/WormBase/API/Service/tree.pm
+++ b/lib/WormBase/API/Service/tree.pm
@@ -62,7 +62,13 @@ sub run {
     }
     $request_name =~ s/^#/?/ if $request_class eq 'Model';
     $dsn  = $self->ace_dsn->dbh;
-    my ($object) = $self->_api->fetch({ class => ucfirst $request_class, name => $request_name, nowrap => 1 });
+
+    # Fetch object: first treat $request_class as ACe class name;
+    # failing that, treat $request_class as WB class, and
+    # let fetch resolve it to appropriate ACe class
+    my ($object) = $self->_api->fetch({ aceclass => ucfirst $request_class, name => $request_name, nowrap => 1 })
+    || $self->_api->fetch({ class => ucfirst $request_class, name => $request_name, nowrap => 1 });
+
 
     my ($tree,$msg);
     if ($object) {

--- a/t/api_tests/tree.t
+++ b/t/api_tests/tree.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+
+# tree display tests
+
+{
+    # Package name is the same as the filename (sans suffix, i.e. no .t ending)
+    package tree;
+
+    # Limit the use of unsafe Perl constructs.
+    use strict;
+
+    # We use Test::More for all tests, so include that here.
+    use Test::More;
+
+    # This variable will hold a reference to a WormBase API object.
+    my $api;
+
+    # A setter method for passing on a WormBase API object from t/api.t to
+    # the subs of this package.
+    sub config {
+        $api = $_[0];
+    }
+
+    # Testing tree display for ACe class that doesn't map to a WB class
+    sub test_tree_display_non_wb_class {
+        my $result = $api->_tools->{tree}->run({
+            'name' => '[cgc5475]:day16-19',
+            'class' => 'Microarray_experiment'
+        });
+
+        ok(@{$result->{tree}}, 'tree returned for Ace class object');
+    }
+
+    # Testing tree display for Multiple ACe classes mapping to same WB class
+    sub test_tree_display_multiple_aceclass {
+        my $result = $api->_tools->{tree}->run({
+            'name' => 'Argon Y',
+            'class' => 'Person'
+        });
+        ok(@{$result->{tree}}, 'tree returned for Author object when requesting WB class Person');
+        is($result->{object}->{class}, 'Author', 'tree for an Author');
+
+    }
+}
+
+1;


### PR DESCRIPTION
#2630

When fetch object for tree display:

- first treat $request_class name as ACe class name;
- failing that, treat $request_class name as WB class, and let fetch resolve it to appropriate ACe class