### PR TITLE
This fixes the problem referred to in #3696, 

### DIFF
--- a/conf/gbrowse/modencode/waterston/waterston.conf
+++ b/conf/gbrowse/modencode/waterston/waterston.conf
@@ -1331,7 +1331,7 @@ vary_fg   = 1
 
 [rainbow_genelet_L2]
 feature       = transcript
-filter        = sub {shift->source_tag =~ /mid-L2_20dC_14hrs/}
+filter        = sub {shift->source_tag =~ /mid-L2_25dC_14hrs/}
 glyph         = rainbow_gene
 data source   = 2846
 track source  = 147
@@ -1370,7 +1370,7 @@ vary_fg = 1
 
 [rainbow_genelet_L3]
 feature       = transcript
-filter        = sub {shift->source_tag =~ /mid-L3_20dC_25hrs/}
+filter        = sub {shift->source_tag =~ /mid-L3_25dC_25hrs/}
 glyph         = rainbow_gene
 data source   = 2847
 track source  = 150
@@ -1522,8 +1522,8 @@ label = 0
 vary_fg = 1
 
 [rainbow_genelet_L4]
-feature       = transcript:mid-L4_20dC_36hrs_post-L1
-filter        = sub {shift->source_tag =~ /mid-L4_20dC_36hrs/}
+feature       = transcript:mid-L4_25dC_36hrs_post-L1
+filter        = sub {shift->source_tag =~ /mid-L4_25dC_36hrs/}
 glyph         = rainbow_gene
 data source   = 2848
 track source   = 146
@@ -2080,7 +2080,7 @@ label         = 0
 
 [rainbow_transcript_L2]
 feature       = transcript
-filter        = sub {shift->source_tag =~ /mid-L2_20dC_14hrs/}
+filter        = sub {shift->source_tag =~ /mid-L2_25dC_14hrs/}
 glyph         = rainbow_gene
 data source   = 2846
 track source  = 147
@@ -2120,7 +2120,7 @@ label         = 0
 
 [rainbow_transcript_L3]
 feature       = transcript
-filter        = sub {shift->source_tag =~ /mid-L3_20dC_25hrs/}
+filter        = sub {shift->source_tag =~ /mid-L3_25dC_25hrs/}
 glyph         = rainbow_gene
 data source   = 2847
 track source  = 150
@@ -2276,7 +2276,7 @@ label         = 0
 
 [rainbow_transcript_L4]
 feature       = transcript
-filter        = sub {shift->source_tag =~ /mid-L4_20dC_36hrs/}
+filter        = sub {shift->source_tag =~ /mid-L4_25dC_36hrs/}
 glyph         = rainbow_gene
 data source   = 2848
 track source  = 146
@@ -2796,7 +2796,7 @@ desciption    = 0
 
 [Hillier_confirmed_introns_L2]
 feature      = intron
-filter       = sub {shift->source_tag =~ /mid-L2_20dC_14hrs/}
+filter       = sub {shift->source_tag =~ /mid-L2_25dC_14hrs/}
 glyph        = box
 data source  = 2846
 track source = 147
@@ -2827,7 +2827,7 @@ desciption    = 0
 
 [Hillier_confirmed_introns_L3]
 feature      = intron
-filter       = sub {shift->source_tag =~ /mid-L3_20dC_25hrs/}
+filter       = sub {shift->source_tag =~ /mid-L3_25dC_25hrs/}
 glyph        = box
 data source  = 2847
 track source = 150
@@ -2951,7 +2951,7 @@ desciption    = 0
 
 [Hillier_confirmed_introns_L4]
 feature      = intron
-filter       = sub {shift->source_tag =~ /mid-L4_20dC_36hrs/}
+filter       = sub {shift->source_tag =~ /mid-L4_25dC_36hrs/}
 glyph        = box
 data source  = 2848
 track source = 146
@@ -3376,7 +3376,7 @@ desciption    = 0
 
 [Hillier_confirmed_polyA_L2]
 feature       = polyA_site
-filter        = sub {shift->source_tag =~ /mid-L2_20dC_14hrs/}
+filter        = sub {shift->source_tag =~ /mid-L2_25dC_14hrs/}
 glyph         = dot
 data source   = 2846
 track source  = 147
@@ -3404,7 +3404,7 @@ desciption    = 0
 
 [Hillier_confirmed_polyA_L3]
 feature      = polyA_site
-filter       = sub {shift->source_tag =~ /mid-L3_20dC_25hrs/}
+filter       = sub {shift->source_tag =~ /mid-L3_25dC_25hrs/}
 glyph        = box
 data source  = 2847
 track source = 150
@@ -3562,7 +3562,7 @@ desciption    = 0
 
 [Hillier_confirmed_polyA_L4]
 feature      = polyA_site
-filter       = sub {shift->source_tag =~ /mid-L4_20dC_36hrs/}
+filter       = sub {shift->source_tag =~ /mid-L4_25dC_36hrs/}
 glyph        = box
 data source  = 2848
 track source = 146
@@ -3971,7 +3971,7 @@ desciption    = 0
 [Hillier_confirmed_SL_L2]
 feature       = SL1_acceptor_site
                 SL2_acceptor_site
-filter        = sub {shift->source_tag =~ /mid-L2_20dC_14hrs/}
+filter        = sub {shift->source_tag =~ /mid-L2_25dC_14hrs/}
 glyph         = dot
 data source   = 2846
 track source  = 147
@@ -4001,7 +4001,7 @@ desciption    = 0
 [Hillier_confirmed_SL_L3]
 feature       = SL1_acceptor_site
                 SL2_acceptor_site
-filter        = sub {shift->source_tag =~ /mid-L3_20dC_25hrs/}
+filter        = sub {shift->source_tag =~ /mid-L3_25dC_25hrs/}
 glyph         = dot
 data source   = 2847
 track source  = 150
@@ -4122,7 +4122,7 @@ desciption    = 0
 [Hillier_confirmed_SL_L4]
 feature       = SL1_acceptor_site
                 SL2_acceptor_site
-filter        = sub {shift->source_tag =~ /mid-L4_20dC_36hrs/}
+filter        = sub {shift->source_tag =~ /mid-L4_25dC_36hrs/}
 glyph         = dot
 data source   = 2848
 track source  = 146


### PR DESCRIPTION
Only this time fixing the correct file.  To verify that there is a problem look at these tracks on the live site:

http://www.wormbase.org/tools/genome/gbrowse/c_elegans_PRJNA13758/?start=14762260;stop=14771996;ref=X;width=800;version=100;flip=0;grid=1;id=f22ca762c7fca02aced7e0e5eb44de31;l=Hillier_confirmed_SL_L2%1EHillier_confirmed_SL_L3%1EHillier_confirmed_SL_L4%1EHillier_confirmed_polyA_L4%1EHillier_confirmed_polyA_L3%1EHillier_confirmed_polyA_L2%1EHillier_confirmed_introns_L4%1EHillier_confirmed_introns_L3%1EHillier_confirmed_introns_L2%1Erainbow_transcript_L4%1Erainbow_genelet_L4%1Erainbow_transcript_L2%1Erainbow_transcript_L3%1Erainbow_genelet_L3%1Erainbow_genelet_L2%1ELOCI%3Aoverview;h_feat=y16b4a.2%40yellow

which are all empty due to the typo in the filter value for these tracks.  Compare to the same region on my test gbrowse:

http://dev.wormbase.org:10004/tools/genome/gbrowse/elegans/?start=6422005;stop=6444994;ref=III;width=800;version=100;flip=0;grid=on;id=4b13ce56bef2c25b6ae36c4db5bd9d1b;l=Hillier_confirmed_SL_L2%1Erainbow_transcript_L4%1Erainbow_genelet_L4%1Erainbow_transcript_L3%1EHillier_confirmed_polyA_L4%1EHillier_confirmed_polyA_L3%1EHillier_confirmed_polyA_L2%1EHillier_confirmed_introns_L4%1EHillier_confirmed_introns_L3%1EHillier_confirmed_introns_L2%1ELOCI%3Aoverview
