### PR TITLE
Redirect WormMine login

### DIFF
--- a/lib/WormBase/Web/Controller/Auth.pm
+++ b/lib/WormBase/Web/Controller/Auth.pm
@@ -183,7 +183,7 @@ sub auth_popup : Chained('auth') PathPart('popup')  Args(0){
 
     #    unless($c->config->{wormmine_path}){
         # WormMine redirects to this url now after it has logged in:
-          $c->res->redirect($c->uri_for('/auth/openid')."?openid_identifier=".$c->req->params->{url}."&redirect=".$c->req->params->{redirect});
+          $c->res->redirect($c->uri_for('/auth/openid')."?openid_identifier=".$c->req->params->{url}."&redirect=".$c->req->params->{redirect}."&oauth2=1");
         # }else{
         #   # Redirect users to WormMine openID login
         #   $c->res->redirect( $c->uri_for('/') . $c->config->{wormmine_path} . '/openid?provider=Google');
@@ -240,7 +240,6 @@ sub auth_wbid :Path('/auth/wbid')  :Args(0) {
 
 sub auth_openid : Chained('auth') PathPart('openid')  Args(0){
      my ( $self, $c) = @_;
-
      $c->user_session->{redirect} = $c->user_session->{redirect} || $c->req->params->{redirect};
      my $redirect = $c->user_session->{redirect};
      my $param = $c->req->params;
@@ -282,7 +281,8 @@ sub auth_openid : Chained('auth') PathPart('openid')  Args(0){
         };
         $c->response->redirect($url);
      # OpenID
-    } elsif (defined $param->{'openid_identifier'} && $param->{'openid_identifier'} =~ /google/i) {
+    } elsif (defined $param->{'openid_identifier'} && $param->{'openid_identifier'} =~ /google/i && $param->{oauth2} eq '1') {
+
         my $callback_url = $c->uri_for('auth/code/google');
         $callback_url->scheme('https') if $c->config->{installation_type} eq 'production';
         my $url = WormBase::Web::ThirdParty::Google->new()->get_authorization_url(

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -1645,6 +1645,7 @@ var Scrolling = (function(){
         }
         var pop_url = '/auth/popup?id='+box_id + '&url=' + provider['url']  + '&redirect=' + location;
         this.popupWin(pop_url);
+        this.signinWormMine(box_id);
       },
 
       popupWin: function(url) {
@@ -1656,7 +1657,19 @@ var Scrolling = (function(){
         // var win2 = window.open(url,"popup","status=no,resizable=yes,height="+h+",width="+w+",left=" + screenx + ",top=" + screeny + ",toolbar=no,menubar=no,scrollbars=no,location=no,directories=no");
         // win2.focus();
         window.location = url;
-      }
+      },
+
+     signinWormMine: function(provider){
+       var mineProviders = {
+         google: 'Google'
+       };
+       var mineUrlBase = 'https://www.wormbase.org/tools/wormmine/openid?provider=%s';
+       var mineUrl;
+       if (mineProviders[provider]){
+         mineUrl = mineUrlBase.replace('%s', mineProviders[provider]);
+         $jq.get(mineUrl);
+       }
+     }
   };
 
 

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -1645,7 +1645,12 @@ var Scrolling = (function(){
         }
         var pop_url = '/auth/popup?id='+box_id + '&url=' + provider['url']  + '&redirect=' + location;
         this.popupWin(pop_url);
-        this.signinWormMine(box_id);
+
+        //if on wormmine page, try sign in to wormmine,
+        // currently not enable for entire site due to redirect issue
+        if (window.location.href.indexOf("tools/wormmine") > -1){
+          this.signinWormMine(box_id);
+        }
       },
 
       popupWin: function(url) {
@@ -1667,7 +1672,8 @@ var Scrolling = (function(){
        var mineUrl;
        if (mineProviders[provider]){
          mineUrl = mineUrlBase.replace('%s', mineProviders[provider]);
-         $jq.get(mineUrl);
+      //   $jq.get(mineUrl);
+         window.location.replace(mineUrl);
        }
      }
   };


### PR DESCRIPTION
Hi @tharris 

**WARNING**: This is a request to **master** branch. In case someone wants to login to WormMine before our next release, this is the web app code part of the fix ready for production.

This is intended as a temporary fix to get WormMine login working again #3774. With this temp fix, if someone currently tries to login **on wormmine page**, it will do an **additional** redirect to the existing WormMine login url for now. This fix will work better, once WormMine is configured to use OAuth2, (suppose it still uses the url to initiate login).

Testing the fix is tricky. The change has been applied to staging, so it can be verified that login to WB still works normally. It's hard to verify it actually does the login as the WormMine site on staging uses the production code of WormBase.