### PR TITLE
Fix for error retrieving sequence features as JSON.

### DIFF
--- a/lib/WormBase/API/Role/Feature.pm
+++ b/lib/WormBase/API/Role/Feature.pm
@@ -63,7 +63,7 @@ sub _get_feature_associations {
 
         push @data, {
             name => $self->_pack_obj($feature),
-            description => $description,
+            description => $description && "$description",
             method => $method && "$method",
             interaction => \@interactions,
             expr_pattern => \@expr_pattern,


### PR DESCRIPTION
Try, e.g.: http://www.wormbase.org/rest/widget/gene/WBGene00004013/feature?content-type=application/json

Gives:

         Content-Type application/json had a problem with your request.
         ***ERROR***
         encountered object 'DAF_16 binding site', but neither allow_blessed enabled nor TO_JSON method available on it at /usr/local/wormbase/extlib/lib/perl5/Catalyst/Action/Serialize/JSON.pm line 39.

There's an AcePerl node leaking into the response object.