### PR TITLE
[check before merging] Don't create UL lists for nested array refs.

### DIFF
--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -582,14 +582,14 @@ END; %]
 
 [% MACRO list_cell_content(cell, separator) BLOCK;
     IF cell.size < 2;
-       FOREACH item IN cell; cell_content(item); END;
+       FOREACH item IN cell; cell_content(item, ' '); END;
     ELSE;
       WRAPPER ul_unless_separator;
         FOREACH item IN cell;
           IF separator;
-            cell_content(item);
+            cell_content(item, ' ');
           ELSE;
-            '<li>' _ cell_content(item) _ '</li>';
+            '<li>' _ cell_content(item, ' ') _ '</li>';
           END;
           IF !(ref(item) && item.defined('evidence')) && !loop.last;
               # scalar.defined always return true, so check item is ref


### PR DESCRIPTION
This is the result of a quick attempt to understand #4007.  It seems excessive to create extra HTML lists for recursive calls to cell_content, so disabling that for everything except top-level calls.

This patch successfully fixes #4007, and I can't *see* any other problems in a few minutes of general browsing around, but needs someone who knows that API a bit better to confirm that there aren't any cases where nested lists might really be wanted.