### PR TITLE
Don't require sub-features for single exon CDSs.

### DIFF
--- a/lib/WormBase/API/Object/Gene.pm
+++ b/lib/WormBase/API/Object/Gene.pm
@@ -1758,7 +1758,8 @@ sub gene_models {
         my @sequences = $cds ? $cds->Corresponding_transcript : ($sequence);
 
         my $len_spliced   = 0;
-        map { $len_spliced += $_->length } map { $_->get_SeqFeatures } $gff->get_SeqFeatures('CDS:WormBase');
+        # Handle single-exon CDS.
+        map { $len_spliced += $_->length } map { if ($_->segments) {$_->get_SeqFeatures} else {$_} } $gff->get_SeqFeatures('CDS:WormBase');
 
         $len_spliced ||= '-';
 

--- a/lib/WormBase/API/Role/Object.pm
+++ b/lib/WormBase/API/Role/Object.pm
@@ -2276,8 +2276,10 @@ sub _fetch_gff_gene {
     my $trans;
     my $GFF = $self->gff_dsn() or die "Cannot connect to GFF database, host:" . $self->host; # should probably log this?
 
-    ($trans) = $GFF->get_features_by_name("$transcript");
-    return $trans;
+    my @feats = $GFF->get_features_by_name("$transcript");
+    if (my ($mrna) = grep {$_->{'type'} eq 'mRNA'} @feats) {
+	return $mrna;
+    }
 }
 
 #----------------------------------------------------------------------

--- a/lib/WormBase/API/Role/Sequence.pm
+++ b/lib/WormBase/API/Role/Sequence.pm
@@ -432,7 +432,7 @@ sub corresponding_all {
         my @sequences = $cds->Corresponding_transcript;
 
         my $len_spliced   = 0;
-        map { $len_spliced += $_->length } map { $_->get_SeqFeatures } $gff->get_SeqFeatures('CDS:WormBase');
+        map { $len_spliced += $_->length } map { if ($_->{'segments'}) {$_->get_SeqFeatures} else {$_} } $gff->get_SeqFeatures('CDS:WormBase');
 
         $len_spliced ||= '-';
 
@@ -860,8 +860,9 @@ sub _build_cds_and_utr {
     my @cds = ();
 
     if ($seq_obj && $self->is_coding){
+        # Check segments as hack to handle single-exon genes.
         @cds = grep { $_->primary_tag ne 'intron' && $_->primary_tag ne 'exon'}
-            map { $_->primary_tag eq 'CDS' ? ($_->get_SeqFeatures) : ($_) }
+            map { $_->primary_tag eq 'CDS' && $_->segments ? ($_->get_SeqFeatures) : ($_) }
                 $seq_obj->get_SeqFeatures();
 
         # sort by stop if on -ve strand


### PR DESCRIPTION
Candidate fix for #4016.

There are two issues here:

- `_fetch_gff_gene` can sometimes return features with the same name but a different type (in the case of the MED-1 gene I was seeing an "Expr_profile" feature returned instead.  I've added some filtering (although please double-check that I'm not now being too stringent).

- Code in several places assumes that CDS features always have sub-features.  This isn't true for single-exon CDSs (regardless of number of exons in the Transcript).