### PR TITLE
249 scroll position bug fix

### DIFF
--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -2353,6 +2353,11 @@ var Scrolling = (function(){
       }
   });
 
+  $jq(window).on('beforeunload', function(){
+    // scroll top upon page refresh
+    $jq(window).scrollTop(0);
+  });
+
   window.WB = WB;
 }(this,document);
 

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -903,14 +903,26 @@
         var url     = nav.attr("href");
 
         content.closest("li").appendTo($jq("#widget-holder").children(column));
+        var heightDefault = content.height();
+        var heightIncrease;
+        var offset = content.offset().top;
 
         if(content.text().length < 4){
           addWidgetEffects(content.parent(".widget-container"));
           ajaxGet(content, url, undefined, function(){
-            Scrolling.sidebarMove();checkSearch(content);
             if ($jq('.multi-view-container').length){
               WB.multiViewInit();
             }
+            console.log([content.offset().top - scrollPos]);
+            var scrollPos = $jq(window).scrollTop();
+            if (content.offset().top < scrollPos - 25){
+              heightIncrease = content.height() - heightDefault;
+              console.log(scrollPos + heightIncrease);
+              $jq('html,body').stop(true,true).animate({
+                scrollTop: scrollPos + heightIncrease
+              }, 0, function(){console.log('Done open ' + widget_name + ' ' +$jq(window).scrollTop());});
+            }
+            Scrolling.sidebarMove();checkSearch(content);
             Layout.resize();
           });
         }
@@ -1257,7 +1269,7 @@ var Scrolling = (function(){
       var elem = document.getElementById(anchor),
           scroll = isScrolledIntoView(elem) ? undefined : $jq(elem).offset().top - system_message - 10;
       if(scroll){
-        body.stop(false, true).animate({
+        body.stop(false, false).animate({
           scrollTop: scroll
         }, 300, 'easeInOutExpo', function(){
           scrollingDown = (body.scrollTop() < scroll) ? 1 : 0;

--- a/root/templates/shared/widgets/expression.tt2
+++ b/root/templates/shared/widgets/expression.tt2
@@ -96,7 +96,7 @@ END;
 
 %]
 <!--fpkm expression field will be loaded with an ajax call-->
-<div id="fpkm_holder">
+<div id="fpkm_holder" style="height:10px;">
     <div class="field">
         <div class="field-title"><span>FPKM expression data:  </span></div>
         <div class="field-content"><div class="loading"><img src="/img/ajax-loader.gif" alt="Loading..." /></div></div>
@@ -109,13 +109,13 @@ $jq(".exprbox").colorbox({width:"90%", inline:true});
 $jq(".exprcamera").colorbox({width:"80%", height:"80%", opacity:"0.4"});
 });
 
-setTimeout(function(){
+//setTimeout(function(){
 // There is some arcana here that will not let us use
 // c.uri_for in this context. It will point to, typically,
 // wormbase.org when prebaking which might not be concurrent
 // with the version being prebaked.
 //    WB.ajaxGet($jq("#fpkm_holder"), "[% c.uri_for("/rest/field", class, fields.name.data.id, "fpkm_expression_summary_ls") %]", {noLoadImg: true});
-    WB.ajaxGet($jq("#fpkm_holder"), "[% '/rest/field/' _ class _ '/' _ fields.name.data.id _ '/fpkm_expression_summary_ls' %]", {noLoadImg: true});
-}, 1000);
+    WB.openField($jq("#fpkm_holder"), "[% '/rest/field/' _ class _ '/' _ fields.name.data.id _ '/fpkm_expression_summary_ls' %]", {noLoadImg: true});
+//}, 1000);
 
 </script>


### PR DESCRIPTION
When widgets and fields load asynchronously, they push succeeding widgets further down. When this happens users sometimes end up looking at wrong part of the webpage. I heard multiple reports on this issue. 

This should address it. If some content finishes loading the above the viewport in webpage, scroll the page down by the height difference due to inserted content.