### PR TITLE
create asset hash based on md5 of wormbase.js and main.css

### DIFF
--- a/root/templates/boilerplate/html
+++ b/root/templates/boilerplate/html
@@ -12,7 +12,7 @@
     </title>
     <link rel="icon" href="/img/favicon.ico" type="image/x-icon" />
     <link type="text/css" href="/css/jquery-ui.min.css" rel="stylesheet" />
-    <link type="text/css" href="/css/main[% c.config.installation_type == 'development' ? '' : '.min' %].css?v[% git_commit_id %]" rel="stylesheet" />
+    <link type="text/css" href="/css/main[% c.config.installation_type == 'development' ? '' : '.min' %].css?v[%- asset_hash | trim -%]" rel="stylesheet" />
   </head>
 
   <body>
@@ -24,7 +24,7 @@
     <script src="/js/jquery-1.9.1.min.js"></script>
     <script src="/js/jquery-ui-1.10.1.custom.min.js"></script>
 
-    <script src="/js/wormbase[% c.config.installation_type == 'development' ? '' : '.min' %].js?v[% git_commit_id %]"></script>
+    <script src="/js/wormbase[% c.config.installation_type == 'development' ? '' : '.min' %].js?v[%- asset_hash | trim -%]"></script>
     <script>
       window.WB || document.write('<script src="/js/wormbase.js"><\/script>');
       [% INCLUDE google_analytics %]

--- a/root/templates/config/main
+++ b/root/templates/config/main
@@ -603,3 +603,15 @@
         print JSON->new->encode($hash);
     [% END; %]
 [% END %]
+
+[% MACRO asset_hash BLOCK -%]
+    [% PERL; -%]
+         open(my $fh_js, "<", "root/js/wormbase.js") or die "cannot open < wormbase.js file: $!";
+         open(my $fh_css, "<", "root/css/main.css") or die "cannot open < main.css file: $!";
+         use Digest::MD5;
+         my $ctx = Digest::MD5->new;
+         $ctx->addfile($fh_js);
+         $ctx->addfile($fh_css);
+         print($ctx->hexdigest);
+    [%- END; %]
+[%- END %]


### PR DESCRIPTION
This makes the static asset hash code update if wormabse.js or main.css is modified. It should be able to avoid the stale cache problem we had in past deployments.