### PR TITLE
Replace fake phenotype_graph_json widget with jsonp calls.

### DIFF
--- a/lib/WormBase/API/Object/Gene.pm
+++ b/lib/WormBase/API/Object/Gene.pm
@@ -1394,19 +1394,20 @@ sub phenotype_graph {
     };
 }
 
-sub phenotype_graph_json {
-  my $self = shift;
-  my $geneId = $self->object;
-# dev server
-#   my $url = 'http://wobr.caltech.edu:82/~azurebrd/cgi-bin/amigo.cgi?action=annotSummaryJson&focusTermId=' . $geneId;
-# live server
-  my $url = 'http://wobr.caltech.edu:81/~azurebrd/cgi-bin/amigo.cgi?action=annotSummaryJson&focusTermId=' . $geneId;
-  my $data = get $url;
-  return {
-    data               => "$data",
-    description        => 'JSON for Phenotype Graph of the gene',
-  };
-}
+# Was used to get around cross server restriction, now replaced with jsonp call from phenotype_graph.tt2
+# sub phenotype_graph_json {
+#   my $self = shift;
+#   my $geneId = $self->object;
+# # dev server
+# #   my $url = 'http://wobr.caltech.edu:82/~azurebrd/cgi-bin/amigo.cgi?action=annotSummaryJson&focusTermId=' . $geneId;
+# # live server
+#   my $url = 'http://wobr.caltech.edu:81/~azurebrd/cgi-bin/amigo.cgi?action=annotSummaryJson&focusTermId=' . $geneId;
+#   my $data = get $url;
+#   return {
+#     data               => "$data",
+#     description        => 'JSON for Phenotype Graph of the gene',
+#   };
+# }
 
 
 

--- a/root/templates/classes/gene/phenotype_graph.tt2
+++ b/root/templates/classes/gene/phenotype_graph.tt2
@@ -8,11 +8,19 @@
 <script type="text/javascript">
 $jq(function(){
 
-  // get exported json from cytoscape desktop via ajax
+// old way with json and fake widget phenotype_graph_json
+//   var graphP = $jq.ajax({
+//     url: 'http://juancarlos.wormbase.org/rest/widget/gene/[% fields.phenotype_graph.data %]/phenotype_graph_json', 
+//     type: 'GET',
+//     dataType: 'json'
+//   });
+
+  // get exported jsonp from cytoscape desktop via ajax
   var graphP = $jq.ajax({
-    url: 'http://juancarlos.wormbase.org/rest/widget/gene/[% fields.phenotype_graph.data %]/phenotype_graph_json', 
+    url: 'http://wobr.caltech.edu:81/~azurebrd/cgi-bin/amigo.cgi?action=annotSummaryJsonp&focusTermId=[% fields.phenotype_graph.data %]',
     type: 'GET',
-    dataType: 'json'
+    jsonpCallback: 'jsonCallback',
+    dataType: 'jsonp'
   });
 
   Promise.all([ graphP ]).then(initCy);

--- a/root/templates/classes/gene/phenotype_graph_json.tt2
+++ b/root/templates/classes/gene/phenotype_graph_json.tt2
@@ -1,1 +1,0 @@
-[% fields.phenotype_graph_json.data %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -1529,12 +1529,6 @@ password_reset_expires = 86400  # 24 hours
                 fields phenotype_by_interaction
         fields drives_overexpression
             </phenotype>
-            <phenotype_graph_json>
-        name phenotype_graph_json
-                title Phenotype Graph JSON
-                display index
-                tooltip JSON for Graph of Phenotypes associated with this gene.
-            </phenotype_graph_json>
             <phenotype_graph>
         name phenotype_graph
                 title Phenotype Graph


### PR DESCRIPTION
phenotype_graph_json widget was used to get around cross server restrictions.  Instead now using jsonp.