### PR TITLE
252 strains

### DIFF
--- a/conf/species/species_ASSEMBLIES.json
+++ b/conf/species/species_ASSEMBLIES.json
@@ -2,9 +2,9 @@
    "b_malayi" : {
       "assemblies" : [
          {
-            "appeared_in" : "WS244",
+            "appeared_in" : "WS251",
             "assembly_accession" : null,
-            "assembly_name" : "B_malayi-3.1",
+            "assembly_name" : "B_malayi-4.0",
             "bioproject" : "PRJNA10729",
             "bioproject_description" : "University of Pittsburgh B. malayi genome project",
             "is_canonical" : true,
@@ -128,6 +128,18 @@
                "Washington University, St. Louis MO"
             ],
             "strain" : "PB4641"
+         },
+         {
+            "appeared_in" : "WS250",
+            "assembly_accession" : null,
+            "assembly_name" : "C_remanei_Oregon_v1",
+            "bioproject" : "PRJNA248909",
+            "bioproject_description" : "University of Oregon University C. remanei PX356 genome project",
+            "is_canonical" : false,
+            "laboratory" : [
+               "University of Texas, Arlington TX"
+            ],
+            "strain" : "PX356"
          }
       ],
       "full_name" : "Caenorhabditis remanei"

--- a/lib/WormBase/API.pm
+++ b/lib/WormBase/API.pm
@@ -104,7 +104,7 @@ sub _build_xapian {
 
   my $ptype_svrp = Search::Xapian::NumberValueRangeProcessor->new(8, "ptype:");
   my $type_svrp = Search::Xapian::StringValueRangeProcessor->new(2);
-  my $species_svrp = Search::Xapian::NumberValueRangeProcessor->new(3, "species:");
+  my $species_svrp = Search::Xapian::StringValueRangeProcessor->new(12, "species:");
   $qp->add_valuerangeprocessor($ptype_svrp);
   $qp->add_valuerangeprocessor($species_svrp);
   $qp->add_valuerangeprocessor($type_svrp);

--- a/lib/WormBase/API/ModelMap.pm
+++ b/lib/WormBase/API/ModelMap.pm
@@ -42,6 +42,7 @@ BEGIN {
             Wbprocess => 'WBProcess',
             Model     => 'Model', #for schema display to work,
             PATO_term => 'PATO_term', #for schema display to work,
+            Sequence_collection => 'Sequence_collection',
         },
         # the following are the tags for extracting a "common" or "public" name
         # for objects automatically. when adding a new one, please consider

--- a/lib/WormBase/API/Service/Xapian.pm
+++ b/lib/WormBase/API/Service/Xapian.pm
@@ -76,10 +76,7 @@ sub search {
       }
     }
 
-    if($species){
-        my $s = $class->_api->config->{sections}->{species_list}->{$species}->{ncbi_taxonomy_id};
-        $q .= " species:$s..$s" if defined $s;
-    }
+    $q = $class->_add_species($q, $species) if $species;
 
     my ($query, $error) =$class->_setup_query($q, $class->qp, 1|2|512|16);
     my $enq       = $class->db->enquire ( $query );
@@ -171,10 +168,7 @@ sub count_estimate {
       }
     }
 
-    if($species){
-        my $s = $class->_api->config->{sections}->{species_list}->{$species}->{ncbi_taxonomy_id};
-        $q .= " species:$s..$s" if defined $s;
-    }
+    $q = $class->_add_species($q, $species) if $species;
 
     my $query=$class->_setup_query($q, $class->qp, 1|2|512|16);
     my $enq       = $class->db->enquire ( $query );
@@ -442,8 +436,7 @@ sub _add_type_range {
 sub _add_species {
     my ($class, $q, $species) = @_;
     if($species){
-        my $s = $class->_api->config->{sections}->{species_list}->{$species}->{ncbi_taxonomy_id};
-        $q .= " species:$s..$s" if defined $s;
+        $q .= " species:$species..$species" if defined $species;
     }
     return $q;
 }

--- a/lib/WormBase/API/Service/Xapian.pm
+++ b/lib/WormBase/API/Service/Xapian.pm
@@ -286,10 +286,13 @@ sub _get_obj {
   my %ret;
   $ret{name} = $self->_pack_search_obj($doc);
   my $species = $ret{name}{taxonomy};
-  if($species =~ m/^(.*)_([^_]*)$/){
+
+  if($species =~ m/^(.*?)_(.*?)(_(.*))?$/){
     my $s = $self->_api->config->{sections}{species_list}{$species};
     $ret{taxonomy}{genus} = $s->{genus} || ucfirst($1);
     $ret{taxonomy}{species} = $s->{species} || $2;
+    my $strain = $s->{strain} || $4;
+    $ret{taxonomy}{species} .= ($strain && " ($strain)") || '';
   }
   $ret{ptype} = $doc->get_value(7) if $doc->get_value(7);
   %ret = %{$self->_split_fields(\%ret, uri_unescape($doc->get_data()))};

--- a/lib/WormBase/API/Service/Xapian.pm
+++ b/lib/WormBase/API/Service/Xapian.pm
@@ -379,14 +379,11 @@ sub _get_tag_info {
 }
 
 # why is species sometimes getting stored weird in xapian?
-# eg. c_caenorhabditis_elegans instead of c_elegans
-#
-# Snips of possible BioProject suffix. For example,
-# 'c_elegans_PRJNA13758' becomes 'c_elegans'. This
-# is (probably) the right behaviour for this sub.
+# eg. c_caenorhabditis_elegans instead of c_elegans.
+# - Any example?
 sub _get_taxonomy {
   my ($self, $doc) = @_;
-  my $taxonomy = $doc->get_value(5);
+  my $taxonomy = $doc->get_value(12);
   return $taxonomy;
 }
 

--- a/root/templates/config/main
+++ b/root/templates/config/main
@@ -195,7 +195,11 @@
         bioproject = data.bioproject || c.config.sections.species_list.$species.bioprojects.keys;
         FOREACH bp IN bioproject;
           IF data.taxonomy && (valid_classes.grep(data.class).size > 0);
-              url = gbrowse_url(species, item.name.class _ ":" _ item.name.id, bp);
+              # if applicable, hack to remove bioproject prefix in WBID(ie. PRJNA248909:FL81_00001 becomes FL81_00001)
+              matched = item.name.id.match('PRJ.+:(\w+)');
+              query = matched ? matched.0 : item.name.id;
+
+              url = gbrowse_url(species, item.name.class _ ":" _ query, bp);
               linkouts.push(label ? "<a href=\"$url\">$label (BioProject $bp)</a>" : "<span id='fade'>[<a href=\"$url\">gbrowse (BioProject $bp)</a>]</span>");
           ELSIF(!search);
               url = gbrowse_url(species, '', bp);

--- a/root/templates/config/main
+++ b/root/templates/config/main
@@ -161,17 +161,21 @@
     # generate the gbrowse url. Figure out which bioproject (cannonical) to use if none supplied
     # generates the gbrowse_img link if image = 1
     MACRO gbrowse_url(taxonomy, id, bioproject, image) BLOCK;
-      IF !bioproject && c.config.sections.species_list.$taxonomy;
+      IF taxonomy.match('(?i).+_(PRJ\w+)');
+        full_taxonomy = taxonomy;
+      ELSIF bioproject;
+        full_taxonomy = taxonomy _ '_' _ bioproject;
+      ELSIF c.config.sections.species_list.defined(taxonomy);
         FOREACH bp IN c.config.sections.species_list.$taxonomy.bioprojects.keys;
           NEXT UNLESS ((!bioproject) || c.config.sections.species_list.$taxonomy.bioproject.$bp.cannonical);
-          bioproject = bp;
+          full_taxonomy = taxonomy _ '_' _ bp;
         END;
       END;
       IF c.config.installation_type.match('^dev');
         # HACK! to direct dev installation to staging, with GBrowse installed
         'http://staging.wormbase.org';
       END;
-      c.uri_for('/tools', 'genome', (image ? 'gbrowse_img' : 'gbrowse'), (bioproject ? taxonomy _ '_' _ bioproject : taxonomy)).path _ (id ? '?name=' _ id : '');
+      c.uri_for('/tools', 'genome', (image ? 'gbrowse_img' : 'gbrowse'), full_taxonomy).path _ (id ? '?name=' _ id : '');
     END;
 
 

--- a/root/templates/config/main
+++ b/root/templates/config/main
@@ -208,13 +208,23 @@
 
 
     MACRO jbrowse_url(taxonomy, position_string, bioproject, is_preview_url) BLOCK;
-      queries = is_preview_url && taxonomy == 'c_elegans' ? {
+      IF is_preview_url && taxonomy == 'c_elegans';
+        queries = {
             data => 'data/' _ taxonomy _ '_simple',
             loc => position_string
-        } : {
+        };
+      ELSIF taxonomy.match('(?i).+_(PRJ\w+)');
+        queries = {
+            data => 'data/' _ taxonomy,
+            loc => position_string
+        };
+      ELSE;
+        queries = {
             data => 'data/' _ taxonomy _ '_' _ bioproject,
             loc => position_string
-          };
+        };
+      END;
+
       IF c.config.installation_type.match('^dev');
         # HACK! to direct dev installation to staging, with GBrowse installed
         'http://staging.wormbase.org';

--- a/root/templates/shared/widgets/downloads.tt2
+++ b/root/templates/shared/widgets/downloads.tt2
@@ -19,6 +19,32 @@
   [% END %]
 [% END %]
 
+[%
+    # get rid of bioproject suffix
+    MACRO parse_species_prefix(species) BLOCK;
+        parts = species.split('_');
+        "${parts.0}_${parts.1}";
+    END;
+%]
+
+
+[%
+    MACRO ftp_link(species, bioproject, release, extension) BLOCK;
+        species = parse_species_prefix(species);
+        release_number = release.match('WS(\d+)').0;
+
+        IF release_number > 236;
+            filename = "${species}.${bioproject}.${release}.${extension}";
+            ftp_url = "releases/$release/species/$species/$bioproject/$filename";
+        ELSE;
+            filename = "${species}.${release}.${extension}";
+            ftp_url = "releases/$release/species/$species/$filename";
+        END;
+
+        "<a href=\"ftp://ftp.wormbase.org/pub/wormbase/${ftp_url}\" target=\"_blank\">" _ "${species}.${extension}" _ '</a>';
+    END;
+%]
+
 [% MACRO parasite_ftp_link(species_name, bioproject, format) BLOCK;
     filename_parts = [species_name, bioproject, c.config.parasite_release, format];
     # specific file or species home directory
@@ -45,11 +71,11 @@ END; %]
        [% END %]
        <td><a href="http://www.ncbi.nlm.nih.gov/bioproject/[% bioproject %]" target="_blank">[% bioproject %]</a>
        </td>
-       <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% option %]">[% (species == 'all') ? 'FTP home' : species_conf.$option.genus _ ' ' _ species_conf.$option.species %]</a></td>
-       <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% option %]/sequence/genomic/[% option %].[% bioproject %].[% constants.acedb_version %].genomic.fa.gz">[% option %].fa.gz</td>
-       <!-- <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% option %]/gff/[% option %].[% bioproject %].[% constants.acedb_version %].annotations.gff2.gz">[% option %].gff2.gz</td> -->
-       <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% option %]/gff/[% option %].[% bioproject %].[% constants.acedb_version %].annotations.gff3.gz">[% option %].gff3.gz</td>
-       <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% option %]/sequence/protein/[% option %].[% bioproject %].[% constants.acedb_version %].protein.fa.gz">[% option %].fa.gz</td>
+       <td><a href="ftp://ftp.wormbase.org/pub/wormbase/species/[% parse_species_prefix(option) %]">[% (species == 'all') ? 'FTP home' : species_conf.$option.genus _ ' ' _ species_conf.$option.species %]</a></td>
+       <td>[% ftp_link(option, bioproject, constants.acedb_version, 'genomic.fa.gz'); %]</td>
+       <!-- <td>[% ftp_link(option, bioproject, constants.acedb_version, 'annotations.gff2.gz'); %]</td> -->
+       <td>[% ftp_link(option, bioproject, constants.acedb_version, 'annotations.gff3.gz'); %]</td>
+       <td>[% ftp_link(option, bioproject, constants.acedb_version, 'protein.fa.gz'); %]</td>
       </tr>
       [% END %]
     [% END %]

--- a/root/templates/species/report.tt2
+++ b/root/templates/species/report.tt2
@@ -7,7 +7,9 @@
         breadcrumbs.push('<span>All Species</span>');
       ELSE;
         breadcrumbs.push('<a href="' _ c.uri_for('/species','all').path _ '">Species</a>');
-        species_name = (s_arr = species.split('_').1) ? species.substr(0,1) _ '. ' _ s_arr : species FILTER ucfirst;
+        species_name = c.config.sections.species_list.defined(species) ?
+            c.config.sections.species_list.$species.title
+            : (s_arr = species.split('_').1) ? species.substr(0,1) _ '. ' _ s_arr : species FILTER ucfirst;
         IF class == 'all';
           breadcrumbs.push('<span class="species">'
                 _ species_name
@@ -35,7 +37,3 @@
       title = breadcrumbs.join(' &raquo; ');
       report_page(title);
 %]
-
-
-
-

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -80,8 +80,8 @@ github_repo = "wormbase/website"
 # Note: This will break log in functionality if WormMine is not running at this path:
 wormmine_path = "tools/wormmine"
 
-wormbase_release = "WS251"
-parasite_release = "WBPS3"  #set in lib/WormBase/Web.pm
+wormbase_release = "WS252"
+parasite_release = "WBPS5"  #set in lib/WormBase/Web.pm
 metadata_path = "/var/lib/jenkins/jobs/staging_build/workspace/metadata"
 
 # Parent directory where R-plots are saves as image files (PNG for now; trailing '/' mandatory).
@@ -4431,6 +4431,59 @@ password_reset_expires = 86400  # 24 hours
            class transcript
       </available_classes>
     </c_remanei>
+
+    <c_remanei_PRJNA248909>
+       title C. remanei (px356)
+       genus Caenorhabditis
+       species remanei
+       common_name =
+       ncbi_taxonomy_id 31234
+       current_version
+       tier                    II
+       display_in_dropdown     no
+       gbrowse                 yes
+       gene_models             yes
+       <bioprojects>
+         <PRJNA248909>
+           title  BioProject PRJNA248909
+         </PRJNA248909>
+       </bioprojects>
+       <source>
+          name WashU
+          url
+          contact
+          email
+      </source>
+
+      <default_widgets>
+         overview
+         downloads
+         assemblies
+      </default_widgets>
+      <widgets>
+      # Built programmatically. This cannot be a custom widget.
+          <downloads>
+              name   downloads
+              title  Downloads
+          </downloads>
+          <assemblies>
+              name   assemblies
+              title  Genome Assemblies
+              fields current_assemblies
+          fields previous_assemblies
+          </assemblies>
+      </widgets>
+     <available_classes>
+           class cds
+           class gene
+           class microarray_results
+           class pcr_oligo
+           class protein
+           class sequence
+           class strain
+           class transcript
+      </available_classes>
+    </c_remanei_PRJNA248909>
 
     <c_sinica>
        title C. sinica

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -4436,6 +4436,7 @@ password_reset_expires = 86400  # 24 hours
        title C. remanei (px356)
        genus Caenorhabditis
        species remanei
+       strain  px356
        common_name =
        ncbi_taxonomy_id 31234
        current_version


### PR DESCRIPTION
#4459 
- allow species in wormbase.conf to optionally have bioproject suffix, to handle multiple strains of the same species
- search/browse with a new species filter that optionally has bioproject suffix 
- fix breadcrumb
- fix and refactor ftp site links for Genome Assemblies widget and Downloads widget (related to #4105)