### PR TITLE
252 separate out million mutation project alleles into another table

### DIFF
--- a/root/templates/classes/gene/genetics.tt2
+++ b/root/templates/classes/gene/genetics.tt2
@@ -6,7 +6,8 @@
    END;
 
    # Alleles
-   WRAPPER $field_block title="Alleles" key="alleles";
+   IF fields.alleles.data || fields.alleles.million_mutation_project_alleles;
+   WRAPPER $field_block title="Alleles";
        build_data_table(
             order=['variation','molecular_change','locations','effects','composite_change','isoform', 'phen_count', 'method_name', 'strain'],
             columns={ variation         => 'Allele',
@@ -21,7 +22,12 @@
             },
             key='alleles',
             classsearch='variation');
+
+        WRAPPER toggle title="Load the million mutation project alleles" lazy=1 href=c.uri_for('/rest','field','gene', object.name.data.id,'million_mutation_project_alleles').path id="million_mutation_project_alleles_toggle";
+        END;
    END;
+   END;
+
 
    # Polymorphisms
    WRAPPER $field_block title="Polymorphisms & Natural variants" key="polymorphisms";

--- a/root/templates/classes/gene/million_mutation_project_alleles.tt2
+++ b/root/templates/classes/gene/million_mutation_project_alleles.tt2
@@ -1,0 +1,16 @@
+[%
+   build_data_table(
+        order=['variation','molecular_change','locations','effects','composite_change','isoform', 'phen_count', 'method_name', 'strain'],
+        columns={ variation         => 'Allele',
+                  molecular_change  => 'Molecular<br /> change',
+                  effects           => 'Protein<br /> effects',
+                  locations         => 'Locations',
+                  phen_count        => '# of<br /> Phenotypes',
+          composite_change  => 'Protein<br />change',
+                  isoform           => 'Isoform',
+                  method_name       => 'Method',
+                  strain            => 'Strain',
+        },
+        passed_data=million_mutation_project_alleles.data,
+        classsearch='variation');
+%]

--- a/t/api_tests/gene.t
+++ b/t/api_tests/gene.t
@@ -216,11 +216,17 @@
 
         can_ok('WormBase::API::Object::Gene', ('alleles'));
         my $alleles = $gene->alleles()->{data};
-        ok(grep($_->{variation}->{label} eq 'gk175216', @$alleles), 'correct allele returned');
+        ok(grep($_->{variation}->{label} eq 'ok640', @$alleles), 'correct allele returned');
+        my ($mmp_allele1) = grep { $_->{method_name} eq 'Million mutation'; } @$alleles;
+        is($mmp_allele1, undef, 'classical alleles correctly excludes million mutation project alleles');
 
         can_ok('WormBase::API::Object::Gene', ('polymorphisms'));
         my $polymorphisms = $gene->polymorphisms()->{data};
         ok(grep($_->{variation}->{label} eq 'WBVar00061322', @$polymorphisms), 'correct polymprphism returned');
+
+        can_ok('WormBase::API::Object::Gene', ('million_mutation_project_alleles'));
+        my $mmp_alleles =  $gene->million_mutation_project_alleles()->{data};
+        ok(grep($_->{variation}->{label} eq 'gk175216', @$mmp_alleles), 'correct million mutation allele returned');
 
     }
 

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -1460,6 +1460,7 @@ password_reset_expires = 86400  # 24 hours
                 display report
                 tooltip Genetic information such as alleles and rearrangements that affect the gene.
                 fields alleles
+                fields million_mutation_project_alleles
                 fields polymorphisms
                 fields rearrangements
                 fields reference_allele


### PR DESCRIPTION
#4001 
In genetics widget on gene page, separate out million mutation project alleles into another table, and place the new table behind a 'load million mutation project alleles' toggle.