### PR TITLE
I added a blacklist for the rest API tests and fixed a couple potenti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Running WormBase Perl API tests for just the gene class:
 
     API_TESTS=gene perl t/api.t
 
+Running WormBase Perl API tests with blacklist
+
+    API_TESTS=1 API_TESTS_BLACKLIST=gene:cds perl t/api.t
+
 Comparative Testing
 -------------------
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -884,22 +884,6 @@ sub widget_GET {
         $c->detach();
         return;
     } else {
-        my $api = $c->model('WormBaseAPI');
-        my $object = ($name eq '*' || $name eq 'all'
-                   ? $api->instantiate_empty(ucfirst $class)
-                   : $api->fetch({ class => ucfirst $class, name => $name }))
-            or die "Could not fetch object $name, $class";
-
-        # Generate and cache the widget.
-        # Load the stash with the field contents for this widget.
-        # The widget itself is loaded by REST; fields are not.
-        my @fields = $c->_get_widget_fields( $class, $widget );
-
-        # Store name on all widgets - needed for display
-        unless (grep /^name$/, @fields) {
-            push @fields, 'name';
-        }
-
         my $skip_datomic = ((( exists $c->config->{"skip_datomic"})
                                && ($c->config->{"skip_datomic"} == 1))
                           ||  ((exists $c->req->params->{"skip-datomic"})
@@ -909,13 +893,30 @@ sub widget_GET {
                         ||  ((exists $c->req->params->{"skip-ace"})
                                && ($c->req->params->{"skip-ace"} == 1)))? 1: 0;
 
-        my ($resp_content, $resp);
+         # Generate and cache the widget.
+        # Load the stash with the field contents for this widget.
+        # The widget itself is loaded by REST; fields are not.
+        my @fields = $c->_get_widget_fields( $class, $widget );
+
+        # Store name on all widgets - needed for display
+        unless (grep /^name$/, @fields) {
+            push @fields, 'name';
+        }
+
+        my ($resp_content, $resp, $object);
         if (not $skip_datomic) {
             my $rest_server = $c->config->{'rest_server'};
             $resp = HTTP::Tiny->new->get("$rest_server/rest/widget/$class/$name/$widget");
             if ($resp->{'status'} == 200 && $resp->{'content'}) {
                 $resp_content = decode_json($resp->{'content'})->{fields};
             }
+        }
+        else {
+            my $api = $c->model('WormBaseAPI');
+            $object = ($name eq '*' || $name eq 'all'
+                   ? $api->instantiate_empty(ucfirst $class)
+                   : $api->fetch({ class => ucfirst $class, name => $name }))
+            or die "Could not fetch object $name, $class";
         }
 
         foreach my $field (@fields) {
@@ -942,7 +943,7 @@ sub widget_GET {
             } else {
                 my $response_content = (exists $resp->{'content'})?
                                                      $resp->{'content'} : '';
-                die "REST query failed at $field: $response_content";
+                warn "REST query failed at $field: $response_content";
             }
 
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -903,7 +903,7 @@ sub widget_GET {
             push @fields, 'name';
         }
 
-        my ($resp_content, $resp, $object);
+        my ($resp_content, $resp);
         if (not $skip_datomic) {
             my $rest_server = $c->config->{'rest_server'};
             $resp = HTTP::Tiny->new->get("$rest_server/rest/widget/$class/$name/$widget");
@@ -911,7 +911,9 @@ sub widget_GET {
                 $resp_content = decode_json($resp->{'content'})->{fields};
             }
         }
-        else {
+
+        my $object;
+        if (not $skip_ace) {
             my $api = $c->model('WormBaseAPI');
             $object = ($name eq '*' || $name eq 'all'
                    ? $api->instantiate_empty(ucfirst $class)
@@ -943,7 +945,7 @@ sub widget_GET {
             } else {
                 my $response_content = (exists $resp->{'content'})?
                                                      $resp->{'content'} : '';
-                warn "REST query failed at $field: $response_content";
+                die "REST query failed at $field: $response_content";
             }
 
 


### PR DESCRIPTION
I made two small but major changes to the code. 

1) I added a flat @API_TESTS_BLACKLIST 

This flag makes it so that you can provide a colon seperated list of tests that you do not wish to run. At first we will be wanting to turn off the gene page tests. As time goes on this list should get longer. 

I have provided examples of how to use the flag in the README.md file. 

2) I re-arranged the REST.pm if statements to make it so that it does not query AceDB at all if skip-ace is turned on.

This was a previous oversight.

3) Minor Change:

I made it so that we get a warning if there is a missing field instead of a  causing the whole API to die. I don't think this will be a problem as long as we make sure there are no warnings before each release.  The benifit is that this way we get more comprehensive warning /. errors during the development of the interfaces

I don't anticipate many more changes to the code. I have decided ( as of now) to not use the already made Perl API tests for the Clojure / Datomic API. I instead will rewrite the tests in Clojure. This not only be better because the tests will be with the proper repo but will also be used for future development beyond Catalyst.


