### PR TITLE
prevent redirecting to fly genes base on matching name 

### DIFF
--- a/lib/WormBase/API/Service/Xapian.pm
+++ b/lib/WormBase/API/Service/Xapian.pm
@@ -261,8 +261,13 @@ sub _check_exact_match {
 
   my $label = $doc->get_value(6);
   my $id = $doc->get_value(1);
+  my $species = $doc->get_value(5);
 
-  return (($label && $q =~ m/\Q$label\E/i) || ($id && $q =~ m/\Q$id\E/i));
+  if ($species && $species ne 'c_elegans') {
+      return 0;  # to reduce mismathes, ignore exact match on entities associated with non- c elegans species
+  } else {
+      return (($label && $q =~ m/\Q$label\E/i) || ($id && $q =~ m/\Q$id\E/i));
+  }
 }
 
 


### PR DESCRIPTION
* for species associated entities, prevent redirect if species is NOT c_elegans
* for other entities (like GO) and c_elegens entities determine match normally

#4912 #4898  