### PR TITLE
display species name in autocomplete suggestions

### DIFF
--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1118,11 +1118,12 @@ cursor:pointer;}
 }
 .autocomplete-item-wrapper {
     font-size: smaller;
-   /* line-height: 20px; */
     overflow:hidden;
     border: 1 solid #666;
 }
 .autocomplete-item-wrapper .species {
+    display: block;
+    line-height: 1em;
     font-size: small;
     color: #666;
 }

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1115,6 +1115,13 @@ cursor:pointer;}
 .ui-autocomplete .ui-menu, .ui-autocomplete .ui-menu-item{
     padding: 0;
     margin: 0;
+
+}
+.ui-autocomplete .ui-menu-item a {
+    border: 1px solid transparent;
+}
+.ui-autocomplete .ui-menu-item a.ui-state-focus {
+    border: 1px solid #999;
 }
 .autocomplete-item-wrapper {
     font-size: smaller;

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1108,6 +1108,24 @@ cursor:pointer;}
 .ui-autocomplete {
   z-index:15 !important;
 }
+.ui-autocomplete ul, .ui-autocomplete li{
+    padding: 0;
+    margin: 0;
+}
+.ui-autocomplete .ui-menu, .ui-autocomplete .ui-menu-item{
+    padding: 0;
+    margin: 0;
+}
+.autocomplete-item-wrapper {
+    font-size: smaller;
+   /* line-height: 20px; */
+    overflow:hidden;
+    border: 1 solid #666;
+}
+.autocomplete-item-wrapper .species {
+    font-size: small;
+    color: #666;
+}
 
 
 

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -702,7 +702,8 @@
           lastXhr = $jq.getJSON( "/search/autocomplete/" + cur_search_type, request, function( data, status, xhr ) {
             if ( xhr === lastXhr ) {
               data.forEach(function(dat) {
-                dat.labelHtml = '<span class="autocomplete-item-wrapper"><span style="margin-bottom: 0px;">' + dat.label + '</span>' + '<span class="species">' + dat.taxonomy + '</span></span>';
+                var speciesHtml = (dat.taxonomy && dat.taxonomy.species) ? '<span class="species">'  + dat.taxonomy.genus + ' ' + dat.taxonomy.species + '</span>' : '';
+                dat.labelHtml = '<span class="autocomplete-item-wrapper"><span>' + dat.label + '</span>' + speciesHtml + '</span>';
               });
               response( data );
             }

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -697,7 +697,7 @@
           lastXhr = $jq.getJSON( "/search/autocomplete/" + cur_search_type, request, function( data, status, xhr ) {
             if ( xhr === lastXhr ) {
               data.forEach(function(dat) {
-                dat.labelHtml = '<div class="autocomplete-item-wrapper">' + dat.label + '<br/>' + '<span class="species">' + dat.taxonomy + '</span></div>';
+                dat.labelHtml = '<span class="autocomplete-item-wrapper"><span style="margin-bottom: 0px;">' + dat.label + '</span>' + '<span class="species">' + dat.taxonomy + '</span></span>';
               });
               response( data );
             }
@@ -709,7 +709,6 @@
         },
         html: true
       });
-
 
 
     }

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -663,34 +663,39 @@
         $jq(this).removeClass("active");
       });
 
-      var proto = $jq.ui.autocomplete.prototype,
-	      initSource = proto._initSource;
+      (function(){
+        // Extend the autocomplete plugin to handle html in items
+        // Adapted based on https://github.com/scottgonzalez/jquery-ui-extensions/blob/master/src/autocomplete/jquery.ui.autocomplete.html.js by Scott González (http://scottgonzalez.com)
 
-      function filter( array, term ) {
-        var matcher = new RegExp( $jq.ui.autocomplete.escapeRegex(term), "i" );
-        return $jq.grep( array, function(value) {
-		  return matcher.test($jq( "<div>" ).html( value.label || value.value || value ).text());
-	    });
-      }
+        var proto = $jq.ui.autocomplete.prototype,
+	        initSource = proto._initSource;
 
-      $jq.extend( proto, {
-	    _initSource: function() {
-		  if ( this.options.html && $jq.isArray(this.options.source) ) {
-			this.source = function( request, response ) {
-			  response( filter( this.options.source, request.term ) );
-			};
-		  } else {
-			initSource.call( this );
-		  }
-	    },
+        function filter( array, term ) {
+          var matcher = new RegExp( $jq.ui.autocomplete.escapeRegex(term), "i" );
+          return $jq.grep( array, function(value) {
+		    return matcher.test($jq( "<div>" ).html( value.label || value.value || value ).text());
+	      });
+        }
 
-	    _renderItem: function( ul, item) {
-		  return $jq( "<li></li>" )
-			.data( "item.autocomplete", item )
-			.append( $jq( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.labelHtml || item.label ) )
-			.appendTo( ul );
-	    }
-      });
+        $jq.extend( proto, {
+	      _initSource: function() {
+		    if ( this.options.html && $jq.isArray(this.options.source) ) {
+			  this.source = function( request, response ) {
+			    response( filter( this.options.source, request.term ) );
+			  };
+		    } else {
+			  initSource.call( this );
+		    }
+	      },
+
+	      _renderItem: function( ul, item) {
+		    return $jq( "<li></li>" )
+			  .data( "item.autocomplete", item )
+			  .append( $jq( "<a></a>" )[ this.options.html ? "html" : "text" ]( item.labelHtml || item.label ) )
+			  .appendTo( ul );
+	      }
+        });
+      })();
 
       searchBox.autocomplete({
         source: function( request, response ) {


### PR DESCRIPTION
#4912
- To help with differentiating same name genes in different species, display species in autocomplete suggestions if appalicable  
- autocomplete json is updated to include structured (packed) taxonomy info
- JQuery ui autocomplete widget is extended to handle html within item