### PR TITLE
fix not able to locate species_ASSEMBLIES.json file from blast service

### DIFF
--- a/lib/WormBase/API/Service/blast_blat.pm
+++ b/lib/WormBase/API/Service/blast_blat.pm
@@ -41,7 +41,7 @@ has 'blast_databases' => (
         my $self = shift;
         my $data;
         my $base_dir = catfile($self->pre_compile->{base});
-        my $assemblies_info = catfile(WormBase::Web->config->{metadata_path}, "ASSEMBLIES." . WormBase::Web->config->{wormbase_release} . ".json");
+        my $assemblies_info = WormBase::Web->path_to('/conf/species/', 'species_ASSEMBLIES.json');
         unless (-e $assemblies_info) {
             error("Misconfigured set-up. Cannot find metadata file that describes assemblies.");
         }

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -95,7 +95,6 @@ wormmine_path = "tools/wormmine"
 
 wormbase_release = "WS254"
 parasite_release = "WBPS6"  #set in lib/WormBase/Web.pm
-metadata_path = "/var/lib/jenkins/jobs/staging_build/workspace/metadata"
 
 # Parent directory where R-plots are saves as image files (PNG for now; trailing '/' mandatory).
 # URL suffix is used for generating the URI that points tot the saved image.


### PR DESCRIPTION
- use the conf/species/species_ASSEMBLIES.json to configure blast service
- conf/species/species_ASSEMBLIES.json have been made to get updated for each release (based on the ftp site)
