### PR TITLE
255 breadcrumb

### DIFF
--- a/lib/WormBase/Web.pm
+++ b/lib/WormBase/Web.pm
@@ -167,13 +167,19 @@ sub _setup_species {
         my $name = $species->{name};
         my $bioproject = $species->{bioproject};
         my $long_name = "$name\_$bioproject";
+        my $assembly_name = $species->{assembly_name};
 
+        my $merged_species;
         if ($original_species->{$long_name}){
             # a typical strain
-            $new_species->{$long_name} = $original_species->{$long_name};
+            $merged_species = $original_species->{$long_name};
+            $merged_species->{assembly_name} = $species->{assembly_name};
+            $new_species->{$long_name} = $merged_species;
         } elsif ($original_species->{$name}->{bioprojects}->{$bioproject}){
             # default strain
-            $new_species->{$name} = $original_species->{$name};
+            $merged_species = $original_species->{$name};
+            $merged_species->{assembly_name} = $species->{assembly_name};
+            $new_species->{$name} = $merged_species;
         }
     }
 
@@ -339,10 +345,10 @@ sub _parse_wb_species {
             my $strain_name = $assembly->{strain};
 
             push @species, {
-                #    'url' => '/Schmidtea_mediterranea_prjna12585/Info/Index',
                 'name' => $species,
                 'bioproject' => $assembly->{bioproject},
-                'label' => "$species_name ($strain_name)"
+                'label' => "$species_name $strain_name",
+                'assembly_name' => $assembly->{assembly_name},
             };
         }
     }
@@ -752,12 +758,12 @@ sub api_tests {
     # Don't check "uninitialized" variables. All variables below are initialized.
     # Perl is just claiming that $pkg has not been set, which is a lie.
     no warnings 'uninitialized';
- 
+
     my $self = shift;
     my $api = $self->model('WormBaseAPI');
     my @tests = <t/api_tests/*.t>;
     foreach my $test (@tests) {
-        next if $API_TESTS ne '1' && $API_TESTS ne basename($test, '.t'); # Only skip if a test set was specified by API_TEST and it is not the current one. 
+        next if $API_TESTS ne '1' && $API_TESTS ne basename($test, '.t'); # Only skip if a test set was specified by API_TEST and it is not the current one.
         next if (defined @API_TESTS_BLACKLIST && ( grep {$_ eq basename($test, '.t')} @API_TESTS_BLACKLIST)); # skip if current test file is in blacklist
         require_ok($test);
         my $pkg = basename($test, '.t') . '::';

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1938,13 +1938,22 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 /* END Formatting for column selection dropdown */
 
 
+#page-title-wrapper {
+  margin: 0 -1em -2.2em 175px;
+  position: relative;
+  top: -2.2em;
+  width: calc(100% - 160px);
+  display: table;
+  z-index: 10;
+}
 
 #page-title {
-  margin:1.5em -1em -2.2em 175px;
-  padding:0.5em 1.5em 0;
-  position:relative;
-  z-index:10;
-  height:3em;
+  height: 3em;
+  display: table-cell;
+  width: 100%;
+  vertical-align: middle;
+  padding: 0 1.5em;
+  /* padding: 0.5em 1.5em 0; */
 }
 
 #page-title.search-bg {
@@ -1961,8 +1970,9 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 }
 
 #page-title .bench-update{
-  padding-top:5px;
-  margin-top: 0.5em;
+  /* padding-top:5px; */
+  /* margin-top: 0.5em; */
+  margin: 15px;
 }
 
 #page-title h2 .note {
@@ -1980,6 +1990,10 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 
 }
 
+#page-title h2 .assembly-name {
+  font-size: 0.6em;
+  font-weight: normal;
+}
 
 /*********************************
 
@@ -3285,6 +3299,8 @@ div.title {
 /* Effects */
 #breadcrumbs {
   position:relative;
+  display: block;
+  margin-top: 8px;
   font-size: 0.8em;
   width:100%;
 }

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -3302,21 +3302,6 @@ div.title {
   width:100%;
 }
 
-/* #breadcrumbs-hide { */
-/*   font-size:0.6em; */
-/*   white-space: nowrap; */
-/*   height:auto; */
-/*   width: auto; */
-/*   overflow:hidden; */
-/*   margin:0 4px 0 12px; */
-/* } */
-/* #breadcrumbs-expand  { */
-/*   position:absolute; */
-/*   left:-12px; */
-/*   top:5px; */
-/*   cursor:pointer; */
-/* } */
-
 span.page-title{
   overflow:hidden;
 }

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1952,8 +1952,7 @@ div#column-dropdown ul li.ui-state-disabled:hover {
   display: table-cell;
   width: 100%;
   vertical-align: middle;
-  padding: 0 1.5em;
-  /* padding: 0.5em 1.5em 0; */
+  padding: 0.5em 1.5em 0.25em;
 }
 
 #page-title.search-bg {
@@ -1963,16 +1962,15 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 #page-title h2 {
   font-size:24px;
   color:#222;
-/*  padding:0.5em 0 0.5em 1em;
-  height:2em; */
   white-space:nowrap;
   position:relative;
 }
 
 #page-title .bench-update{
-  /* padding-top:5px; */
-  /* margin-top: 0.5em; */
-  margin: 15px;
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 15;
 }
 
 #page-title h2 .note {
@@ -3300,7 +3298,6 @@ div.title {
 #breadcrumbs {
   position:relative;
   display: block;
-  margin-top: 8px;
   font-size: 0.8em;
   width:100%;
 }

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1941,10 +1941,10 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 
 #page-title {
   margin:1.5em -1em -2.2em 175px;
-  padding:0 1.5em 0 0;
+  padding:0.5em 1.5em 0;
   position:relative;
   z-index:10;
-  height:3.5em;
+  height:3em;
 }
 
 #page-title.search-bg {
@@ -1954,14 +1954,15 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 #page-title h2 {
   font-size:24px;
   color:#222;
-  padding:0.5em 0 0.5em 1em;
-  height:2em;
+/*  padding:0.5em 0 0.5em 1em;
+  height:2em; */
   white-space:nowrap;
   position:relative;
 }
 
-#page-title h2 .bench-update{
+#page-title .bench-update{
   padding-top:5px;
+  margin-top: 0.5em;
 }
 
 #page-title h2 .note {
@@ -3278,25 +3279,26 @@ div.title {
 /* Effects */
 #breadcrumbs {
   position:relative;
+  font-size: 0.8em;
   width:100%;
 }
 
-#breadcrumbs-hide {
-  font-size:0.6em;
-  white-space: nowrap;
-  height:auto;
-  width: auto;
-  overflow:hidden;
-  margin:0 4px 0 12px;
-}
-#breadcrumbs-expand  {
-  position:absolute;
-  left:-12px;
-  top:5px;
-  cursor:pointer;
-}
+/* #breadcrumbs-hide { */
+/*   font-size:0.6em; */
+/*   white-space: nowrap; */
+/*   height:auto; */
+/*   width: auto; */
+/*   overflow:hidden; */
+/*   margin:0 4px 0 12px; */
+/* } */
+/* #breadcrumbs-expand  { */
+/*   position:absolute; */
+/*   left:-12px; */
+/*   top:5px; */
+/*   cursor:pointer; */
+/* } */
 
-#breadcrumbs span.page-title{
+span.page-title{
   overflow:hidden;
 }
 

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1962,7 +1962,7 @@ div#column-dropdown ul li.ui-state-disabled:hover {
 #page-title h2 {
   font-size:24px;
   color:#222;
-  white-space:nowrap;
+  /* white-space:nowrap; */
   position:relative;
 }
 

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1974,6 +1974,12 @@ div#column-dropdown ul li.ui-state-disabled:hover {
   color:#333;
 }
 
+#page-title .assembly-name {
+  color: #333;
+  margin-left: 5px;
+
+}
+
 
 /*********************************
 

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -317,7 +317,7 @@
 
       window.onhashchange = Layout.readHash;
       window.onresize = Layout.resize;
-      Layout.Breadcrumbs.init();
+//      Layout.Breadcrumbs.init();
       if(location.hash.length > 0){
         Layout.readHash();
       }else if(layout = widgetHolder.data("layout")){

--- a/root/js/wormbase.js
+++ b/root/js/wormbase.js
@@ -317,7 +317,7 @@
 
       window.onhashchange = Layout.readHash;
       window.onresize = Layout.resize;
-//      Layout.Breadcrumbs.init();
+
       if(location.hash.length > 0){
         Layout.readHash();
       }else if(layout = widgetHolder.data("layout")){
@@ -1277,52 +1277,6 @@ var Layout = (function(){
       }
     }
 
-
-
-
-  var Breadcrumbs = (function(){
-    var bc = $jq("#breadcrumbs"),
-        bExp = false,
-        hiddenContainer,
-        bWidth,
-        bCount;
-
-    function init() {
-      if (!bc || ((bCount = bc.children().size()) < 3)) { return; }
-      var children = bc.children(),
-          hidden = children.slice(0, (bCount - 2)),
-          shown = children.slice((bCount - 2)),
-          expand;
-      bc.empty();
-      hiddenContainer = $jq('<span id="breadcrumbs-hide"></span>');
-      hiddenContainer.append(hidden).children().after(' &raquo; ');
-
-      bc.append('<span id="breadcrumbs-expand" class="ui-icon-large ui-icon-triangle-1-e tl" tip="exapand"></span>').append(hiddenContainer).append(shown);
-      bc.children(':last').addClass("page-title").before(" &raquo; ");
-
-      expand = $jq("#breadcrumbs-expand");
-      expand.click( function(){
-        (bExp = !bExp) ? show($jq(this)) : hide($jq(this));
-      });
-      bWidth = hiddenContainer.width();
-      hide(expand);
-    }
-
-    function show(expand){
-      hiddenContainer.animate({width:bWidth}, function(){ hiddenContainer.css("width", "auto");}).css("visibility", 'visible');
-      expand.attr("tip", "minimize").removeClass("ui-icon-triangle-1-e").addClass("ui-icon-triangle-1-w");
-    }
-
-    function hide(expand){
-      hiddenContainer.animate({width:0}, function(){ hiddenContainer.css("visibility", 'hidden');});
-      expand.attr("tip", "expand").removeClass("ui-icon-triangle-1-w").addClass("ui-icon-triangle-1-e");
-    }
-
-    return {
-     init: init
-    }
-  })();
-
   return {
       resize: resize,
       deleteLayout: deleteLayout,
@@ -1334,7 +1288,6 @@ var Layout = (function(){
       readHash: readHash,
       getLeftWidth: getLeftWidth,
       updateLayout: updateLayout,
-      Breadcrumbs: Breadcrumbs,
       newLayout: newLayout
   }
 })();

--- a/root/templates/resources/report.tt2
+++ b/root/templates/resources/report.tt2
@@ -19,9 +19,5 @@
       END;
     END;
 
-    title = breadcrumbs.join(" &raquo; ");
-    report_page(title);
+    report_page(breadcrumbs);
 %]
-
-
-

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -21,13 +21,12 @@
     [% FOREACH type IN data.keys -%]
         <b>[% type_label = '' _ type; type_label.replace('_',' ') %]</b>[% IF data.$type.size > 0 %]:
           [% IF (type == 'curatorial_remarks'); '<br />'; END; %]
-          [% tags2link(data.$type, ((type == 'curatorial_remarks') ? '<br />' : '; '), 'items') %]
+          [% tags2link(data.$type, ((type == 'curatorial_remarks') ? '<br />' : '; '), 'items', 50) %]
         [% END %]
         [% UNLESS loop.last %]<br>[% END %]
     [% END %]
 [% IF text %]    </div>
     <div class="ev-more">
-      <div class="v ev-more-line"></div>
       <div class="ev-more-text"><span>[% label ? label : 'evidence' %]</span></div>
       <div class="v ui-icon ui-icon-triangle-1-s"></div>
     </div>

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -27,6 +27,7 @@
     [% END %]
 [% IF text %]    </div>
     <div class="ev-more">
+      <div class="v ev-more-line"></div>
       <div class="ev-more-text"><span>[% label ? label : 'evidence' %]</span></div>
       <div class="v ui-icon ui-icon-triangle-1-s"></div>
     </div>

--- a/root/templates/shared/sidebar_structure.tt2
+++ b/root/templates/shared/sidebar_structure.tt2
@@ -52,7 +52,8 @@
         <div style="clear:both"></div>
       </div>
 
-      <div id="page-title" class="[% section %]-bg">
+    <div id="page-title-wrapper" class="[% section %]-bg">
+      <div id="page-title">
       [% UNLESS c.req.action == 'me' %]
           [% wbid = get_star_id(object.name.data.id || c.req.path) %]
           [% make_star(wbid) %]
@@ -82,6 +83,7 @@
       </h2>
 
       </div>
+    </div>
     [% END %]
 
 

--- a/root/templates/shared/sidebar_structure.tt2
+++ b/root/templates/shared/sidebar_structure.tt2
@@ -52,12 +52,23 @@
         <div style="clear:both"></div>
       </div>
 
-      [% title = title_string %]
       <div id="page-title" class="[% section %]-bg">
       [% UNLESS c.req.action == 'me' %]
           [% wbid = get_star_id(object.name.data.id || c.req.path) %]
           [% make_star(wbid) %]
       [% END; %]
+
+
+      [% IF breadcrumbs.size < 3;
+          titles = breadcrumbs;
+          breadcrumbs = [];
+      ELSE;
+          titles = breadcrumbs.slice(2);
+          breadcrumbs = breadcrumbs.slice(0,1);
+      END; %]
+      [% title = titles.join(" &raquo; "); %]
+      [% breadcrumbs_string = breadcrumbs.join(" &raquo; "); %]
+
       [%  '<span id="breadcrumbs">' _ breadcrumbs_string _ '</span>'; %]
       <h2>
           [% title %]

--- a/root/templates/shared/sidebar_structure.tt2
+++ b/root/templates/shared/sidebar_structure.tt2
@@ -52,14 +52,14 @@
         <div style="clear:both"></div>
       </div>
 
-      [% title = '<span id="breadcrumbs">' _ title _ '</span>' %]
+      [% title = title_string %]
       <div id="page-title" class="[% section %]-bg">
-      <h2
-        [% UNLESS c.req.action == 'me' %]
-          >
+      [% UNLESS c.req.action == 'me' %]
           [% wbid = get_star_id(object.name.data.id || c.req.path) %]
           [% make_star(wbid) %]
-        [% ELSE; '>'; END; %]
+      [% END; %]
+      [%  '<span id="breadcrumbs">' _ breadcrumbs_string _ '</span>'; %]
+      <h2>
           [% title %]
     [% IF c.request.param('from');
         from_uri = c.request.param('from');

--- a/root/templates/species/report.tt2
+++ b/root/templates/species/report.tt2
@@ -11,6 +11,10 @@
         species_name = c.config.sections.species_list.defined(species) ?
             c.config.sections.species_list.$species.title
             : (s_arr = species.split('_').1) ? species.substr(0,1) _ '. ' _ s_arr : species FILTER ucfirst;
+
+        assembly = c.config.sections.species_list.defined(species) ?
+            c.config.sections.species_list.$species.assembly_name : '';
+
         IF class == 'all';
           breadcrumbs.push('<span class="species">'
                 _ species_name
@@ -23,7 +27,8 @@
           IF species != 'all';
             breadcrumbs.push('<span class="species"><a href="' _ c.uri_for('/species',species).path _ '">'
                       _ species_name
-                      _ '</a></span>');
+                      _ '</a></span>'
+                      _ "<span class=\"assembly-name\">(Genome assembly: $assembly)</span>");
           END;
           UNLESS object.name.data.label;
             breadcrumbs.push('<span>'_ class_title  _ '</span>');

--- a/root/templates/species/report.tt2
+++ b/root/templates/species/report.tt2
@@ -3,6 +3,7 @@
 [%
       species = species || object.name.data.taxonomy;
       breadcrumbs = [];
+
       IF (species == 'all' && class=='all');
         breadcrumbs.push('<span>All Species</span>');
       ELSE;
@@ -24,18 +25,14 @@
                       _ species_name
                       _ '</a></span>');
           END;
-          titles = [];
           UNLESS object.name.data.label;
-            titles.push('<span>'_ class_title  _ '</span>');
+            breadcrumbs.push('<span>'_ class_title  _ '</span>');
           ELSE;
-            titles.push('<a href="' _ c.uri_for('/species',species,class).path _ '">'
+            breadcrumbs.push('<a href="' _ c.uri_for('/species',species,class).path _ '">'
                     _ class_title _ '</a>');
-            titles.push('<span>' _ markup(object.name.data.label, 0, 1, 1, 1) _ '</span>');
+            breadcrumbs.push('<span>' _ markup(object.name.data.label, 0, 1, 1, 1) _ '</span>');
           END;
         END;
       END;
-
-      breadcrumbs_string = breadcrumbs.join(' &raquo; ');
-      title_string = titles.join(' &raquo; ');
-      report_page();
+      report_page(breadcrumbs);
 %]

--- a/root/templates/species/report.tt2
+++ b/root/templates/species/report.tt2
@@ -18,7 +18,8 @@
         IF class == 'all';
           breadcrumbs.push('<span class="species">'
                 _ species_name
-                _ '</span>');
+                _ '</span>'
+                _ "<span class=\"assembly-name\">(Genome assembly: $assembly)</span>");
         ELSE;
           class_title = c.config.sections.species.$class.title || c.config.sections.resources.$class.title;
           IF !(object.name.data.id.defined);

--- a/root/templates/species/report.tt2
+++ b/root/templates/species/report.tt2
@@ -24,16 +24,18 @@
                       _ species_name
                       _ '</a></span>');
           END;
+          titles = [];
           UNLESS object.name.data.label;
-            breadcrumbs.push('<span>'_ class_title  _ '</span>');
+            titles.push('<span>'_ class_title  _ '</span>');
           ELSE;
-            breadcrumbs.push('<a href="' _ c.uri_for('/species',species,class).path _ '">'
+            titles.push('<a href="' _ c.uri_for('/species',species,class).path _ '">'
                     _ class_title _ '</a>');
-            breadcrumbs.push('<span>' _ markup(object.name.data.label, 0, 1, 1, 1) _ '</span>');
+            titles.push('<span>' _ markup(object.name.data.label, 0, 1, 1, 1) _ '</span>');
           END;
         END;
       END;
 
-      title = breadcrumbs.join(' &raquo; ');
-      report_page(title);
+      breadcrumbs_string = breadcrumbs.join(' &raquo; ');
+      title_string = titles.join(' &raquo; ');
+      report_page();
 %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -4256,7 +4256,7 @@ password_reset_expires = 86400  # 24 hours
     </c_elegans>
 
    <c_elegans_PRJNA275000>
-      title C. elegans (CB4856)
+      title C. elegans CB4856
       genus Caenorhabditis
       species elegans
       strain CB4856
@@ -4517,7 +4517,7 @@ password_reset_expires = 86400  # 24 hours
     </c_remanei>
 
     <c_remanei_PRJNA248909>
-       title C. remanei (px356)
+       title C. remanei px356
        genus Caenorhabditis
        species remanei
        strain  px356


### PR DESCRIPTION
- makes the full breadcrumbs always shown on a page (in smaller font and above the page title)
- extract and display assembly name on page title or breadcrumb (on species/ pages. Resource/ pages are not affected) 

#4998

