### PR TITLE
255 widget data source

### DIFF
--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -927,9 +927,11 @@ sub widget_GET {
             my $data;
             if ($resp_content && $resp_content->{$field}) {
                 $data = $resp_content->{$field};
+                $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
             } elsif ((not $skip_ace) && $object->can($field)) {
                 # try Perl API
                 $data = $object->$field;
+                $c->stash->{data_from_ace} = 1;  # widget contains data from acedb
                 if ($c->config->{fatal_non_compliance}) {
                     # checking for data compliance can be an overhead, only use
                     # in testing env where its explicitly enabled

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -2076,6 +2076,21 @@ li.visible div.widget-container {
   height:150px;
 }
 
+.widget-container .widget-data-source-wrapper {
+  position: absolute;
+  top: 5px;
+  right: 30px;
+}
+.widget-container .widget-data-source {
+  border-radius: 5px;
+  background-color: white;
+  padding: 4px;
+  display: inline-block;
+}
+.widget-container .widget-data-source.datomic {
+  background-color: yellow;
+}
+
 /* colour changes for the different types of widgets */
 
 #widget-me {

--- a/root/templates/shared/generic/rest_widget.tt2
+++ b/root/templates/shared/generic/rest_widget.tt2
@@ -1,15 +1,22 @@
-[% IF c.config.installation_type == 'development' ||
-    c.config.installation_type == 'staging' %]
-    <div class="widget-data-source-wrapper">
-    [% IF data_from_datomic %]
-        <span class="widget-data-source datomic">Datomic</span>
+[% MACRO widget_data_source BLOCK %]
+    [%# display the data source of the widget to help with testing %]
+    [%# development and staging instance only %]
+    [% IF c.config.installation_type == 'development' ||
+        c.config.installation_type == 'staging' %]
+        <div class="widget-data-source-wrapper">
+        [% IF data_from_datomic %]
+            <span class="widget-data-source datomic"
+                title="This widget contains data from Datomic.">Datomic</span>
+        [% END %]
+        [% IF data_from_ace %]
+            <span class="widget-data-source"
+             title="This widget contains data from ACeDB.">ACeDB</span>
+        [% END %]
+        </div>
     [% END %]
-    [% IF data_from_ace %]
-        <span class="widget-data-source">ACeDB</span>
-    [% END %]
-    </div>
 [% END %]
 
+[% widget_data_source %]
 [% empty_widget_check %]
 [% PROCESS $child_template %]
 

--- a/root/templates/shared/generic/rest_widget.tt2
+++ b/root/templates/shared/generic/rest_widget.tt2
@@ -1,3 +1,15 @@
+[% IF c.config.installation_type == 'development' ||
+    c.config.installation_type == 'staging' %]
+    <div class="widget-data-source-wrapper">
+    [% IF data_from_datomic %]
+        <span class="widget-data-source datomic">Datomic</span>
+    [% END %]
+    [% IF data_from_ace %]
+        <span class="widget-data-source">ACeDB</span>
+    [% END %]
+    </div>
+[% END %]
+
 [% empty_widget_check %]
 [% PROCESS $child_template %]
 

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -55,10 +55,11 @@ twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 
 skip_ace     = 0  # 1 to skip 0 to not skip
 skip_cache   = 0  # 1 to skip 0 to not skip
-skip_datomic = 1  # 1 to skip 0 to not skip
+skip_datomic = 0  # 1 to skip 0 to not skip
 
 #Datomic to catayl location
-rest_server = "http://23.20.57.180:8130"
+rest_server = "http://52.90.214.72:3000"
+
 
 # This is the site-wide (dismissable) system message.
 # The id is used to make sure a new message won't be hidden


### PR DESCRIPTION
- add tag to indicate data for each widget (Datomic or ACeDB)
    - a widget may contain data from both, if a fallback to ACeDB occurs due to a missing field in data returned from Datomic API
- turn off skip_datomic flag in wormbase.conf 
- configure datomic server address to the Datomic dev server
