### PR TITLE
(hotfix to production) fix problem in deletion variation on minus strand 

### DIFF
--- a/lib/WormBase/API/Object/Variation.pm
+++ b/lib/WormBase/API/Object/Variation.pm
@@ -1345,7 +1345,7 @@ sub _compile_nucleotide_changes {
 
             my $segment = $self->_segments->[0];
             if ($segment) {
-                $wt  = $segment->dna;
+                $wt  = lc $segment->dna;
             }
 
             # CGH tested deletions.
@@ -1643,11 +1643,8 @@ sub _build_sequence_strings {
             # Reverse complement the mutant sequence
             $strand = '-';  # Set the $strand flag if not already set.
             unless ($mut =~ /transposon/i) {
-                $mut = reverse $mut;
-                $mut =~ tr/[acgt]/[tgca]/;
-
-                $wt = reverse $wt;
-                $wt =~ tr/[acgt]/[tgca]/;
+                $mut = &reverse_complement($mut);
+                $wt = &reverse_complement($wt);
             }
         }
 

--- a/t/api_tests/variation.t
+++ b/t/api_tests/variation.t
@@ -81,6 +81,19 @@
 
     }
 
+    sub test_negative_strand_deletion {
+        my $variation = $api->fetch({ class => 'Variation', name => 'WBVar00275092' });
+
+        can_ok('WormBase::API::Object::Variation', ('_build_sequence_strings'));
+
+        my ($wt_seq,$mut_seq,$wt_full,$mut_full) = $variation->_build_sequence_strings();
+
+        my $match_wt_seq = $wt_seq =~ /acaccattgaacttccaattgcatACGGAAGCGGTAGACGCATTTCGCAAACGGGTAGACCTGTTAGGCTGAAATTTGAATTTTTGATAGGATTATCAGTATATATAGTTATCCATACTTATTGATGGTTACTTTCGACCCAAAACCGAAGCCTAATGGAGCCGCACCAATTCCTGCGGATATCAGCCATAccagaactatcacgtaatttatacg/i;
+        ok($match_wt_seq, 'correct wild type sequence');
+        ok($mut_seq =~ /acaccattgaacttccaattgcatccagaactatcacgtaatttatacg/i, 'correct mutant sequence');
+
+    }
+
 }
 
 1;


### PR DESCRIPTION
#5042 

Hi @tharris, here is pull request for hotfixing the variation problem on production site. I tested the fix by comparing the deleted sequence (always reported on + strand) with the reverse complement of transcript sequence (all - strand, which were related to the bug). I just wrote to the curators. We can probably pull this in once hear back from them. Thank you!