### PR TITLE
256 rest

### DIFF
--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -885,6 +885,8 @@ sub widget_GET {
         if ($resp->{'status'} == 200 && $resp->{'content'}) {
             $c->stash->{fields} = decode_json($resp->{'content'})->{fields};
             $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
+        } elsif ($resp->{'status'} == 500 && $c->config->{fatal_non_compliance}) {
+            die "failed to load widget $class::$widget from datomic-to-catalyst";
         }
     }
 
@@ -957,7 +959,10 @@ sub widget_GET {
         }
     }
 
-    $c->set_cache($key => $c->stash->{fields}) if $c->stash->{fields} && !$skip_cache;
+    if ($c->stash->{fields}) {
+        $c->set_cache($key => $c->stash->{fields}) unless $skip_cache;
+    }
+
 
     # Forward to the view to render HTML, set stash variables
     if ( $content_type eq 'text/html' ) {

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -859,21 +859,9 @@ sub widget_GET {
           $c->go('search', 'search');
     }
 
-    my $skip_cache = (((exists $c->config->{skip_cache})
-                          && ($c->config->{skip_cache} == 1))
-                      ||  ((exists $c->request->params->{"skip-cache"})
-                           && ($c->request->params->{"skip-cache"} == 1))) ? 1 : 0;
-
-    my $skip_datomic = ((( exists $c->config->{"skip_datomic"})
-                             && ($c->config->{"skip_datomic"} == 1))
-                            ||  ((exists $c->req->params->{"skip-datomic"})
-                                 && ($c->req->params->{"skip-datomic"} == 1)))? 1: 0;
-
-    my $skip_ace = (((exists $c->config->{"skip_ace"})
-                         && ($c->config->{"skip_ace"} == 1))
-                        ||  ((exists $c->req->params->{"skip-ace"})
-                             && ($c->req->params->{"skip-ace"} == 1)))? 1: 0;
-
+    my $skip_cache = $c->config->{skip_cache} || $c->request->params->{"skip-cache"};
+    my $skip_datomic = $c->config->{skip_datomic} || $c->request->params->{"skip-datomic"};
+    my $skip_ace = $c->config->{skip_ace} || $c->request->params->{"skip-ace"};
 
 
     # check Datomic first before checking cache (for now)

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1705,9 +1705,9 @@ sub field_GET {
         if ($resp->{'status'} == 200 && $resp->{'content'}) {
             $c->stash->{$field} = decode_json($resp->{'content'})->{$field};
             $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
-            $c->set_cache($key => $c->stash->{$field});
+            $c->set_cache($key => $c->stash->{$field}) unless $skip_cache;
         } elsif ($resp->{'status'} == 500 && $c->config->{fatal_non_compliance}) {
-            #die "failed to load field $class::$field from datomic-to-catalyst";
+            die "failed to load field $class::$field from datomic-to-catalyst";
         }
     }
 
@@ -1715,7 +1715,7 @@ sub field_GET {
         my ( $cached_data, $cache_source ) = $c->check_cache($key);
         if ($cached_data && (ref $cached_data eq 'HASH')){
             $c->stash->{$field} = $cached_data;
-            $c->stash->{served_from_cache} = $key unless $skip_cache;
+            $c->stash->{served_from_cache} = $key;
         }
     }
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1715,7 +1715,7 @@ sub field_GET {
         my ( $cached_data, $cache_source ) = $c->check_cache($key);
         if ($cached_data && (ref $cached_data eq 'HASH')){
             $c->stash->{$field} = $cached_data;
-            $c->stash->{served_from_cache} = $key;
+            $c->stash->{served_from_cache} = $key unless $skip_cache;
         }
     }
 
@@ -1728,7 +1728,7 @@ sub field_GET {
       my $data   = $object->$field();
       $c->stash->{$field} = $data;
       $c->stash->{data_from_ace} = 1;
-      $c->set_cache($key => $data);
+      $c->set_cache($key => $data) unless $skip_cache;
 
       # Include the full uri to the *requested* object.
       # IE the page on WormBase where this should go.
@@ -1736,7 +1736,7 @@ sub field_GET {
     }
 
     # Supress boilerplate wrapping.
-    $c->stash->{noboiler} = 1 unless $skip_cache;
+    $c->stash->{noboiler} = 1;
 
     my $uri = $c->uri_for( "/species", $class, $name )->path;
 


### PR DESCRIPTION
- fix widget_GET and field_GET
- check datomic-to-catalyst before checking cache
   * fallback to cache, then ACeDB, if d-to-c fails
   * cache d-to-c widget results (to be used in case d-to-c fails)