### PR TITLE
avoid extra saving to cache of d-to-c response

### DIFF
--- a/lib/WormBase/CHI/Driver/Couch.pm
+++ b/lib/WormBase/CHI/Driver/Couch.pm
@@ -68,6 +68,12 @@ sub fetch {
     return $doc->{data};
 }
 
+sub has_document {
+    my ($self, $key) = @_;
+
+    return $self->_couchagent->get_document({ id => $self->escape_key($key) });
+}
+
 sub fetch_multi_hashref {
     my ($self, $keys) = @_;
 

--- a/lib/WormBase/Web.pm
+++ b/lib/WormBase/Web.pm
@@ -570,6 +570,15 @@ sub get_example_object {
 #  Helper methods for interacting with the cache.
 #
 ########################################
+sub has_cache {
+    my ($self, $key, $cache_name) = @_;
+
+    return unless $self->config->{cache}{enabled};
+    $cache_name ||= 'default';
+
+    my $cache = $self->cache($cache_name);
+    return $cache->has_document($key);
+}
 
 sub check_cache {
     my ($self, $key, $cache_name) = @_;
@@ -578,6 +587,7 @@ sub check_cache {
     $cache_name ||= 'default';
 
     my $cache = $self->cache($cache_name);
+
     unless ($cache) {
         $self->log->error('No cache backend with name ', $cache_name);
         return;

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -874,7 +874,7 @@ sub widget_GET {
         if ($resp->{'status'} == 200 && $resp->{'content'}) {
             $c->stash->{fields} = decode_json($resp->{'content'})->{fields};
             $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
-            $c->set_cache($key => $c->stash->{fields}) unless $skip_cache;
+            $c->set_cache($key => $c->stash->{fields}) unless $skip_cache || $c->has_cache($key);;
         } elsif ($resp->{'status'} == 500 && $c->config->{fatal_non_compliance}) {
             die "failed to load widget $class::$widget from datomic-to-catalyst";
         }
@@ -1705,7 +1705,7 @@ sub field_GET {
         if ($resp->{'status'} == 200 && $resp->{'content'}) {
             $c->stash->{$field} = decode_json($resp->{'content'})->{$field};
             $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
-            $c->set_cache($key => $c->stash->{$field}) unless $skip_cache;
+            $c->set_cache($key => $c->stash->{$field}) unless $skip_cache || $c->has_cache($key);
         } elsif ($resp->{'status'} == 500 && $c->config->{fatal_non_compliance}) {
             die "failed to load field $class::$field from datomic-to-catalyst";
         }


### PR DESCRIPTION
- implement has_cache and call it before set_cache 
     - for both widget_GET and field_GET after successfully getting data from d-to-c
- limitation: 
     - fallback cache will get outdated if d-to-c gets updated between releases => will consider better with of expiring cache later if necessary.