### PR TITLE
fix PATO display in phenotype table on non-gene page #5356

### DIFF
--- a/lib/WormBase/API/Role/Phenotype.pm
+++ b/lib/WormBase/API/Role/Phenotype.pm
@@ -8,11 +8,20 @@ use Moose::Role;
 #
 #######################################################
 
-has 'features' => (
-    is  => 'ro',
-    lazy => 1,
-    builder => '_build_features',
+has 'phenotype' => (
+    is       => 'ro',
+    required => 1,
+    lazy     => 1,
+    builder  => '_build__phenotypes',
 );
+
+has 'phenotype_not_observed' => (
+    is       => 'ro',
+    required => 1,
+    lazy     => 1,
+    builder  => '_build__phenotypes_not_observed',
+);
+
 
 #######################################
 #

--- a/lib/WormBase/API/Role/Phenotype.pm
+++ b/lib/WormBase/API/Role/Phenotype.pm
@@ -142,27 +142,6 @@ sub _get_phenotypes_by_experiment {
 }
 
 
-sub _get_pato {
-    my ($self, $phenotype_info_obj, $pato_tag) = @_;
-    my @entities = $phenotype_info_obj->at($pato_tag);
-
-    my @patos = map {
-        my ($entity_type, $entity_term, $pato_term) = $_->row();
-        $pato_term = $pato_term && $pato_term->Name;
-        return {
-            pato_evidence => {
-                entity_type => $entity_type && "$entity_type",
-                entity_term => $self->_pack_obj($entity_term),
-                pato_term   =>  $pato_term ? "$pato_term" : 'abnormal',
-            },
-            key => join('_', "$entity_term", "$pato_term")
-        };
-    } @entities;
-
-    return @patos;
-}
-
-
 sub _get_rnai_info {
    my ($self, $rnai_obj) = @_;
 

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -563,7 +563,9 @@ END; %]
 
 [% MACRO pato_evidence(obj) BLOCK;
     entity_type = obj.entity_type || 'Entity';
-    entity_type.replace('_', ' ') _ ': ';
+    '<strong>' _
+    entity_type.replace('_', ' ') _
+    '</strong>: ';
     tag2link(obj.entity_term) _ ', ' _ obj.pato_term;
 END; %]
 
@@ -1038,11 +1040,12 @@ END;
 
    WRAPPER $field_block title="Phenotypes" key="phenotypes";
 
-       build_data_table(order=['phenotype','description','evidence'],
+       build_data_table(order=['phenotype','description','entities_affected', 'evidence'],
                         columns={
                         phenotype    => 'Phenotype',
                         description => 'Phenotype Definition',
-                       evidence  => 'Evidence'
+                        entities_affected => 'Entities affected',
+                        evidence  => 'Evidence'
                     },
                     key='phenotypes');
     END;
@@ -1053,9 +1056,10 @@ END;
 
    WRAPPER $field_block title="Phenotypes NOT Observed" key="phenotypes_not_observed";
 
-       build_data_table(order=['phenotype','evidence'],
+       build_data_table(order=['phenotype','entities_affected','evidence'],
                         columns={
                         phenotype    => 'Phenotype',
+                        entities_affected => 'Entities affected',
                         evidence  => 'Evidence'
                     },
                     key='phenotypes_not_observed');

--- a/root/templates/shared/widgets/phenotypes.tt2
+++ b/root/templates/shared/widgets/phenotypes.tt2
@@ -1,3 +1,5 @@
 [% phenotypes %]
 
 [% phenotypes_not_observed %]
+
+[% phenotype_submission_link; %]


### PR DESCRIPTION
- add Entities_affected column to phenotype tables on everything other than gene page
( gene page already handles PATO correctly)