### PR TITLE
(PR to master) fix bug in template code

### DIFF
--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -35,6 +35,8 @@
   [% ELSE %]
     [% IF text.exists('label') %]
 	[% tag2link(text) %]
+    [% ELSIF( text.match(".*\\<[^>]+>.*") ) # don't link html %]
+    [% "$text" %]
     [% ELSE %]
 	[% markup(text) %]
     [% END %]
@@ -581,7 +583,7 @@ END; %]
             searchlink(cell.class, cell.id, cell.id);
           END;
       ELSIF cell.defined('evidence');
-          evidence(cell.evidence,table_name _ index, cell.text, 'details');
+          evidence(cell.evidence,table_name _ index, cell_content(cell.text, separator), 'details');
       ELSIF cell.defined('interaction');
           interaction_cell(cell);
       ELSIF cell.defined('xrefs');


### PR DESCRIPTION
- prevent mistakenly marked up html in evidence field with value undef, ie: `{"text": [some html_content], "evidence": null}`