### PR TITLE
re-write the standard phenotype table 

### DIFF
--- a/lib/WormBase/API/Role/Object.pm
+++ b/lib/WormBase/API/Role/Object.pm
@@ -1049,7 +1049,7 @@ sub _build_phenotypes_data {
         {
             phenotype   => $self->_pack_obj($_),
             evidence => $ev ? {evidence => $ev} : undef,
-            entities_affected => @patos ? \@patos : undef,
+            entity => @patos ? \@patos : undef,
             description => $desc && "$desc",
             remarks     => $remark && "$remark",
         };

--- a/root/templates/classes/gene/phenotype.tt2
+++ b/root/templates/classes/gene/phenotype.tt2
@@ -1,26 +1,4 @@
 
-[% phenotype_table_settings = '
-"drawCallback": WB.partitioned_table(0),
-"columnDefs": [
-            { "targets": 0, "visible": true },
-            { "targets": 2, "width": "40%" },
-        ],
-        "autoWidth": false
-'%]
-
-[% MACRO process_phenotype_data(phenotype_data) BLOCK;
-    # NOTE: phenotype_data is mutated by this MACRO
-    FOREACH dat IN phenotype_data;
-        IF dat.entity;
-            dat.entity_formatted = dat.entity;
-        ELSE;
-            dat.entity_formatted = '<span class="fade">N/A</span>';
-        END;
-    END;
-   END;
-%]
-
-
 [% WRAPPER $field_block title="Phenotypes" key="phenotype" %]
    Alleles for which the sequence change is known are listed in <b>boldface</b>.<br><br>
 
@@ -28,16 +6,7 @@
     <p><i>The following phenotypes have been observed in [% object.name.data.label %]</i>:</p>
 
 [%
-    process_phenotype_data(fields.phenotype.data);
-    build_data_table(order=['phenotype', 'entity_formatted', 'evidence'],
-            columns={
-                phenotype  => 'Phenotype',
-                entity_formatted => 'Entities Affected',
-                evidence => 'Supporting Evidence',
-            }, key='phenotype',
-            passed_data = fields.phenotype.data,  #fields.phenotype.data has been mutated by process_phenotype_data
-            style = phenotype_table_settings
-    );
+    build_phenotype_table(key='phenotype');
 %]
     <br />
 [% END %]
@@ -46,17 +15,7 @@
 
 [% WRAPPER $field_block title="Phenotype not observed" key="phenotype_not_observed" %]
    [% WRAPPER toggle title="<i>The following phenotypes have been reported as NOT observed in " _  object.name.data.label _ "</i>" %]
-      [%
-        process_phenotype_data(fields.phenotype_not_observed.data);
-        build_data_table(order=['phenotype','entity_formatted', 'evidence'],
-            columns={
-                phenotype  => 'Phenotype',
-                entity_formatted => 'Entities Affected',
-                evidence => 'Supporting Evidence',
-        }, key='phenotype_not_observed',
-        passed_data = fields.phenotype_not_observed.data,  #fields.phenotype_not_observed.data has been mutated by process_phenotype_data
-        style = phenotype_table_settings);
-      %]
+      [% build_phenotype_table(key='phenotype_not_observed'); %]
    [% END %]
     <br />
 [% END %]

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -1038,34 +1038,56 @@ END;
     fields.
 %]
 
+[% MACRO build_phenotype_table(custom_args) BLOCK;
+
+    phenotype_table_args = {
+        order => ['phenotype', 'entity', 'evidence'],
+        columns => {
+            phenotype  => 'Phenotype',
+            entity => 'Entities Affected',
+            evidence => 'Supporting Evidence',
+        },
+        key => 'phenotypes',
+        style => '
+            "drawCallback": WB.partitioned_table(0),
+            "columnDefs": [
+                { "targets": 0, "visible": true },
+                { "targets": 1,
+                  "render": function ( data, type, full, meta ) {
+                    return data || "<span class=\"fade\">N/A</span>";
+                  }
+                },
+                { "targets": 2, "width": "40%" },
+            ],
+            "autoWidth": false'
+
+    };
+
+    phenotype_table_args.import(custom_args || {});
+
+    build_data_table(
+        order=phenotype_table_args.order,
+        columns=phenotype_table_args.columns,
+        passed_data=phenotype_table_args.passed_data,
+        key=phenotype_table_args.key,
+        style=phenotype_table_args.style
+    );
+END %]
+
+
 [% MACRO phenotypes BLOCK ;
 
-   WRAPPER $field_block title="Phenotypes" key="phenotypes";
-
-       build_data_table(order=['phenotype','description','entities_affected', 'evidence'],
-                        columns={
-                        phenotype    => 'Phenotype',
-                        description => 'Phenotype Definition',
-                        entities_affected => 'Entities affected',
-                        evidence  => 'Evidence'
-                    },
-                    key='phenotypes');
+    WRAPPER $field_block title="Phenotypes" key="phenotypes";
+       build_phenotype_table(key='phenotypes');
     END;
 END;
 %]
 
 [% MACRO phenotypes_not_observed BLOCK ;
 
-   WRAPPER $field_block title="Phenotypes NOT Observed" key="phenotypes_not_observed";
-
-       build_data_table(order=['phenotype','entities_affected','evidence'],
-                        columns={
-                        phenotype    => 'Phenotype',
-                        entities_affected => 'Entities affected',
-                        evidence  => 'Evidence'
-                    },
-                    key='phenotypes_not_observed');
-      END;
+    WRAPPER $field_block title="Phenotypes NOT Observed" key="phenotypes_not_observed";
+        build_phenotype_table(key='phenotypes_not_observed');
+    END;
 
  END;
 %]


### PR DESCRIPTION
- re-write the standard phenotype table to match the style of the gene page phenotype table
- rename json key "entity" of phenotype field in Catalyst to match d2c

#5599