### PR TITLE
259 species config

### DIFF
--- a/conf/species/parasite_species_tree.json
+++ b/conf/species/parasite_species_tree.json
@@ -47,7 +47,33 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Trichinella_nativa_prjna179527/Info/Index/",
+                        "url" : "/Trichinella_britovi_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_britovi_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella britovi"
+                     },
+                     {
+                        "url" : "/Trichinella_murrelli_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_murrelli_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella murrelli"
+                     },
+                     {
+                        "url" : "/Trichinella_nativa_prjna179527/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -55,12 +81,133 @@
                               "url" : "/Trichinella_nativa_prjna179527/Info/Index",
                               "children" : null,
                               "label" : "PRJNA179527"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_nativa_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
                            }
                         ],
                         "label" : "Trichinella nativa"
                      },
                      {
-                        "url" : "/Trichinella_spiralis_prjna12603/Info/Index/",
+                        "url" : "/Trichinella_nelsoni_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_nelsoni_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella nelsoni"
+                     },
+                     {
+                        "url" : "/Trichinella_papuae_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_papuae_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella papuae"
+                     },
+                     {
+                        "url" : "/Trichinella_patagoniensis_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_patagoniensis_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella patagoniensis"
+                     },
+                     {
+                        "url" : "/Trichinella_pseudospiralis_iss13prjna257433/Info/SpeciesLanding/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_pseudospiralis_iss13prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_pseudospiralis_iss141prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_pseudospiralis_iss176prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_pseudospiralis_iss470prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_pseudospiralis_iss588prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella pseudospiralis"
+                     },
+                     {
+                        "url" : "/Trichinella_t6_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_t6_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella sp. T6"
+                     },
+                     {
+                        "url" : "/Trichinella_t8_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_t8_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella sp. T8"
+                     },
+                     {
+                        "url" : "/Trichinella_t9_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_t9_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella sp. T9"
+                     },
+                     {
+                        "url" : "/Trichinella_spiralis_prjna12603/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -68,9 +215,28 @@
                               "url" : "/Trichinella_spiralis_prjna12603/Info/Index",
                               "children" : null,
                               "label" : "PRJNA12603"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_spiralis_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
                            }
                         ],
                         "label" : "Trichinella spiralis"
+                     },
+                     {
+                        "url" : "/Trichinella_zimbabwensis_prjna257433/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Trichinella_zimbabwensis_prjna257433/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA257433"
+                           }
+                        ],
+                        "label" : "Trichinella zimbabwensis"
                      }
                   ],
                   "label" : "Trichinella"
@@ -510,7 +676,7 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Toxocara_canis_prjeb533/Info/Index/",
+                        "url" : "/Toxocara_canis_prjeb533/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -518,6 +684,12 @@
                               "url" : "/Toxocara_canis_prjeb533/Info/Index",
                               "children" : null,
                               "label" : "PRJEB533"
+                           },
+                           {
+                              "summary" : "University of Melbourne genome project",
+                              "url" : "/Toxocara_canis_prjna248777/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA248777"
                            }
                         ],
                         "label" : "Toxocara canis"
@@ -529,7 +701,7 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Wuchereria_bancrofti_prjeb536/Info/Index/",
+                        "url" : "/Wuchereria_bancrofti_prjeb536/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -537,6 +709,12 @@
                               "url" : "/Wuchereria_bancrofti_prjeb536/Info/Index",
                               "children" : null,
                               "label" : "PRJEB536"
+                           },
+                           {
+                              "summary" : "Case Western Reserve University genome project",
+                              "url" : "/Wuchereria_bancrofti_prjna275548/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA275548"
                            }
                         ],
                         "label" : "Wuchereria bancrofti"
@@ -573,6 +751,25 @@
                   "url" : "/",
                   "children" : [
                      {
+                        "url" : "/Ditylenchus_destructor_prjna312427/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "Huazhong Agricultural University genome project",
+                              "url" : "/Ditylenchus_destructor_prjna312427/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA312427"
+                           }
+                        ],
+                        "label" : "Ditylenchus destructor"
+                     }
+                  ],
+                  "label" : "Ditylenchus"
+               },
+               {
+                  "url" : "/",
+                  "children" : [
+                     {
                         "url" : "/Globodera_pallida_prjeb123/Info/Index/",
                         "aliases" : [],
                         "children" : [
@@ -584,6 +781,19 @@
                            }
                         ],
                         "label" : "Globodera pallida"
+                     },
+                     {
+                        "url" : "/Globodera_rostochiensis_prjeb13504/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "University of Edinburgh genome project",
+                              "url" : "/Globodera_rostochiensis_prjeb13504/Info/Index",
+                              "children" : null,
+                              "label" : "PRJEB13504"
+                           }
+                        ],
+                        "label" : "Globodera rostochiensis"
                      }
                   ],
                   "label" : "Globodera"
@@ -637,12 +847,12 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Panagrellus_redivivus/Info/Index/",
+                        "url" : "/Panagrellus_redivivus_prjna186477/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
-                              "summary" : "WormBase genome project",
-                              "url" : "/Panagrellus_redivivus/Info/Index",
+                              "summary" : "California Institute of Technology genome project",
+                              "url" : "/Panagrellus_redivivus_prjna186477/Info/Index",
                               "children" : null,
                               "label" : "PRJNA186477"
                            }
@@ -782,7 +992,7 @@
                         "aliases" : [],
                         "children" : [
                            {
-                              "summary" : "ARRAY(0x7f9d92f63040) genome project",
+                              "summary" : "ARRAY(0x7fa9282745b0) genome project",
                               "url" : "/Strongyloides_ratti_prjeb125/Info/Index",
                               "children" : null,
                               "label" : "PRJEB125"
@@ -912,12 +1122,12 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Caenorhabditis_angaria/Info/Index/",
+                        "url" : "/Caenorhabditis_angaria_prjna51225/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
-                              "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_angaria/Info/Index",
+                              "summary" : "California Institute of Technology genome project",
+                              "url" : "/Caenorhabditis_angaria_prjna51225/Info/Index",
                               "children" : null,
                               "label" : "PRJNA51225"
                            }
@@ -925,12 +1135,12 @@
                         "label" : "Caenorhabditis angaria"
                      },
                      {
-                        "url" : "/Caenorhabditis_brenneri/Info/Index/",
+                        "url" : "/Caenorhabditis_brenneri_prjna20035/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
                               "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_brenneri/Info/Index",
+                              "url" : "/Caenorhabditis_brenneri_prjna20035/Info/Index",
                               "children" : null,
                               "label" : "PRJNA20035"
                            }
@@ -938,12 +1148,12 @@
                         "label" : "Caenorhabditis brenneri"
                      },
                      {
-                        "url" : "/Caenorhabditis_briggsae/Info/Index/",
+                        "url" : "/Caenorhabditis_briggsae_prjna10731/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
                               "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_briggsae/Info/Index",
+                              "url" : "/Caenorhabditis_briggsae_prjna10731/Info/Index",
                               "children" : null,
                               "label" : "PRJNA10731"
                            }
@@ -951,12 +1161,12 @@
                         "label" : "Caenorhabditis briggsae"
                      },
                      {
-                        "url" : "/Caenorhabditis_elegans/Info/Index/",
+                        "url" : "/Caenorhabditis_elegans_prjna13758/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
                               "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_elegans/Info/Index",
+                              "url" : "/Caenorhabditis_elegans_prjna13758/Info/Index",
                               "children" : null,
                               "label" : "PRJNA13758"
                            }
@@ -964,12 +1174,12 @@
                         "label" : "Caenorhabditis elegans"
                      },
                      {
-                        "url" : "/Caenorhabditis_japonica/Info/Index/",
+                        "url" : "/Caenorhabditis_japonica_prjna12591/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
                               "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_japonica/Info/Index",
+                              "url" : "/Caenorhabditis_japonica_prjna12591/Info/Index",
                               "children" : null,
                               "label" : "PRJNA12591"
                            }
@@ -977,12 +1187,12 @@
                         "label" : "Caenorhabditis japonica"
                      },
                      {
-                        "url" : "/Caenorhabditis_remanei/Info/Index/",
+                        "url" : "/Caenorhabditis_remanei_prjna53967/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
                               "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_remanei/Info/Index",
+                              "url" : "/Caenorhabditis_remanei_prjna53967/Info/Index",
                               "children" : null,
                               "label" : "PRJNA53967"
                            }
@@ -990,12 +1200,12 @@
                         "label" : "Caenorhabditis remanei"
                      },
                      {
-                        "url" : "/Caenorhabditis_sinica/Info/Index/",
+                        "url" : "/Caenorhabditis_sinica_prjna194557/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
-                              "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_sinica/Info/Index",
+                              "summary" : "University of Edinburgh genome project",
+                              "url" : "/Caenorhabditis_sinica_prjna194557/Info/Index",
                               "children" : null,
                               "label" : "PRJNA194557"
                            }
@@ -1003,12 +1213,12 @@
                         "label" : "Caenorhabditis sinica"
                      },
                      {
-                        "url" : "/Caenorhabditis_tropicalis/Info/Index/",
+                        "url" : "/Caenorhabditis_tropicalis_prjna53597/Info/Index/",
                         "aliases" : [],
                         "children" : [
                            {
-                              "summary" : "WormBase genome project",
-                              "url" : "/Caenorhabditis_tropicalis/Info/Index",
+                              "summary" : "Genome Institute at Washington University genome project",
+                              "url" : "/Caenorhabditis_tropicalis_prjna53597/Info/Index",
                               "children" : null,
                               "label" : "PRJNA53597"
                            }
@@ -1104,8 +1314,9 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Heligmosomoides_polygyrus_prjeb1203/Info/Index/",
+                        "url" : "/Heligmosomoides_polygyrus_prjeb1203/Info/SpeciesLanding/",
                         "aliases" : [
+                           "Heligmosomoides bakeri",
                            "Heligmosomoides bakeri"
                         ],
                         "children" : [
@@ -1114,6 +1325,12 @@
                               "url" : "/Heligmosomoides_polygyrus_prjeb1203/Info/Index",
                               "children" : null,
                               "label" : "PRJEB1203"
+                           },
+                           {
+                              "summary" : "University of Edinburgh genome project",
+                              "url" : "/Heligmosomoides_polygyrus_prjeb15396/Info/Index",
+                              "children" : null,
+                              "label" : "PRJEB15396"
                            }
                         ],
                         "label" : "Heligmosomoides polygyrus"
@@ -1315,7 +1532,7 @@
                         "label" : "Echinococcus canadensis"
                      },
                      {
-                        "url" : "/Echinococcus_granulosus_prjeb121/Info/Index/",
+                        "url" : "/Echinococcus_granulosus_prjeb121/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -1323,6 +1540,12 @@
                               "url" : "/Echinococcus_granulosus_prjeb121/Info/Index",
                               "children" : null,
                               "label" : "PRJEB121"
+                           },
+                           {
+                              "summary" : "Chinese National Human Genome Center genome project",
+                              "url" : "/Echinococcus_granulosus_prjna182977/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA182977"
                            }
                         ],
                         "label" : "Echinococcus granulosus"
@@ -1470,7 +1693,7 @@
                   "url" : "/",
                   "children" : [
                      {
-                        "url" : "/Taenia_asiatica_prjeb532/Info/Index/",
+                        "url" : "/Taenia_asiatica_prjeb532/Info/SpeciesLanding/",
                         "aliases" : [],
                         "children" : [
                            {
@@ -1478,9 +1701,28 @@
                               "url" : "/Taenia_asiatica_prjeb532/Info/Index",
                               "children" : null,
                               "label" : "PRJEB532"
+                           },
+                           {
+                              "summary" : "Chinese Academy of Agricultural Sciences genome project",
+                              "url" : "/Taenia_asiatica_prjna299871/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA299871"
                            }
                         ],
                         "label" : "Taenia asiatica"
+                     },
+                     {
+                        "url" : "/Taenia_saginata_prjna71493/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "Chinese Academy of Agricultural Sciences genome project",
+                              "url" : "/Taenia_saginata_prjna71493/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA71493"
+                           }
+                        ],
+                        "label" : "Taenia saginata"
                      },
                      {
                         "url" : "/Taenia_solium_prjna170813/Info/Index/",
@@ -1708,6 +1950,25 @@
          {
             "url" : "/",
             "children" : [
+               {
+                  "url" : "/",
+                  "children" : [
+                     {
+                        "url" : "/Gyrodactylus_salaris_prjna244375/Info/Index/",
+                        "aliases" : [],
+                        "children" : [
+                           {
+                              "summary" : "Natural History Museum, University of Oslo genome project",
+                              "url" : "/Gyrodactylus_salaris_prjna244375/Info/Index",
+                              "children" : null,
+                              "label" : "PRJNA244375"
+                           }
+                        ],
+                        "label" : "Gyrodactylus salaris"
+                     }
+                  ],
+                  "label" : "Gyrodactylus"
+               },
                {
                   "url" : "/",
                   "children" : [

--- a/lib/WormBase/Web.pm
+++ b/lib/WormBase/Web.pm
@@ -197,7 +197,7 @@ sub _setup_parasite_species {
     # determine the latest parasite release
     $c->config->{parasite_release} = _get_latest_release($c);
 
-    my $species_file_remote_path = "/pub/wormbase/parasite/releases/". $c->config->{parasite_release} . "/species_tree.json";
+    my $species_file_remote_path = "http://parasite.wormbase.org/Multi/Ajax/species_tree";
     my $species_file_local_path = $c->path_to('/conf/species/', 'parasite_species_tree.json');
 
     my $parasite_species_trees = _get_json($c,
@@ -222,7 +222,7 @@ sub _get_json {
         $json = _parse_json($json_string);  # update reference in closure
     };
 
-    local *_process_remote_copy = sub {
+    local *_process_ftp_copy = sub {
 
         my ($ftp) = @_;
         my $fh;
@@ -239,6 +239,16 @@ sub _get_json {
 
     };
 
+    local *_process_http_copy = sub {
+        my ($content) = @_;
+        $json = _parse_json($content);
+        # update local copy
+        my $fh;
+        open($fh, '>', $local_copy_path);
+        print $fh $content;
+        close $fh;
+    };
+
     sub _parse_json {
         my ($my_json_string) = @_;
         return (new JSON)->allow_nonref->utf8->relaxed->decode($my_json_string);
@@ -246,11 +256,15 @@ sub _get_json {
 
     # consider remote copy only on a development instance
     if ($c->config->{installation_type} eq 'development'){
-        $c->_with_ftp_site(\&_process_remote_copy, \&_process_local_copy);
+        if ($remote_path =~ /^https?:.+/) {
+            $c->_with_http($remote_path, \&_process_http_copy, \&_process_local_copy);
+        } else {
+            $c->_with_ftp(\&_process_ftp_copy, \&_process_local_copy);
+        }
     }else{
         _process_local_copy();
     }
-    # unlike with javascript, _with_ftp_site is blocking
+    # unlike with javascript, _with_ftp is blocking
 
     return $json;
 }
@@ -299,18 +313,18 @@ sub _get_latest_release {
 
     # consider remote copy only on a development instance
     if ($c->config->{installation_type} eq 'development'){
-        $c->_with_ftp_site(\&_process_remote_copy, \&_process_local_copy);
+        $c->_with_ftp(\&_process_remote_copy, \&_process_local_copy);
     }else{
         _process_local_copy();
     }
 
-    # unlike with javascript, _with_ftp_site is blocking
+    # unlike with javascript, _with_ftp is blocking
     return 'WBPS' .  $latest_release_number;
 }
 
 
 # helper method to handle setup and teardown of ftp site connection
-sub _with_ftp_site {
+sub _with_ftp {
     my ($c, $on_success, $on_error, @args) = @_;
 
     my $error;
@@ -333,6 +347,23 @@ sub _with_ftp_site {
 
     $on_error->($error, @args) if $error;
 
+}
+
+sub _with_http {
+    my ($c, $url, $on_success, $on_error, @args) = @_;
+    my $ua = LWP::UserAgent->new;
+    $ua->timeout(5);
+
+    my $response = $ua->get($url);
+
+    my $error;
+    if ($response->is_success) {
+        $on_success->($response->content(), @args);
+    } else {
+        $error = $response->status_line;
+        warn "!!!FAILED!!! to retrieve species configuration from $url:\n$error";
+    }
+    $on_error->($error, @args) if $error;
 }
 
 sub _parse_wb_species {

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1270,9 +1270,9 @@ sub _gene_name_changes_helper {
 
     my $release = $c->config->{wormbase_release};
     my $name_change_file_path = "/pub/wormbase/releases/$release/species/c_elegans/PRJNA13758/annotation/c_elegans.PRJNA13758.$release.changed_CGC_names.txt";
-    $c->_with_ftp_site(\&read_file_to_stash,
-                       \&handle_error,
-                       $name_change_file_path);
+    $c->_with_ftp(\&read_file_to_stash,
+                  \&handle_error,
+                  $name_change_file_path);
 }
 
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1207,12 +1207,7 @@ sub _gene_name_changes_helper {
     }
 
     local *read_file_to_stash = sub {
-        my ($ftp, $path, $namespace) = @_;
-        my $fh;
-        my $content;
-        open( $fh, '>', \$content) || die "cannot open fh";
-        $ftp->get($path, $fh);
-        close $fh;
+        my ($content) = @_;
 
         # parse changed_CGC_names file
         my @sections = split '\n\n', $content;
@@ -1269,10 +1264,10 @@ sub _gene_name_changes_helper {
     };
 
     my $release = $c->config->{wormbase_release};
-    my $name_change_file_path = "/pub/wormbase/releases/$release/species/c_elegans/PRJNA13758/annotation/c_elegans.PRJNA13758.$release.changed_CGC_names.txt";
-    $c->_with_ftp(\&read_file_to_stash,
-                  \&handle_error,
-                  $name_change_file_path);
+    my $name_change_file_path = "ftp://ftp.wormbase.org/pub/wormbase/releases/$release/species/c_elegans/PRJNA13758/annotation/c_elegans.PRJNA13758.$release.changed_CGC_names.txt";
+    $c->_with_ftp($name_change_file_path,
+                  \&read_file_to_stash,
+                  \&handle_error);
 }
 
 


### PR DESCRIPTION
- fix parasite species tree is moved from ftp site to REST API
- allow fetching species json from both FTP (WB central) and REST API (ParaSite)
- refactor code for fetching from FTP site to return content instead of ftp client object
      * able to handle `ls` and `get` access on ftp client