### PR TITLE
259 cache support for datomic widgets with time-based cache expiry

### DIFF
--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -879,7 +879,7 @@ sub widget_GET {
 
     if (!@datomic_endpoints) {
         # when Datomic-to-catalyst or swagger.json on datomic-to-catalyst server isn't available
-        if ($cached_data && $c->config->{installation_type} eq 'production') {
+        if ($cached_data && !$c->config->{fatal_non_compliance}) {
             $c->stash->{fields} = $cached_data;
             $c->stash->{served_from_cache} = $key;
         } else {
@@ -1760,7 +1760,7 @@ sub field_GET {
 
     if (!@datomic_endpoints) {
         # when Datomic-to-catalyst or swagger.json on datomic-to-catalyst server isn't available
-        if ($cached_data && $c->config->{installation_type} eq 'production') {
+        if ($cached_data && !$c->config->{fatal_non_compliance}) {
             $c->stash->{$field} = $cached_data;
             $c->stash->{served_from_cache} = $key;
         } else {

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -910,6 +910,9 @@ sub widget_GET {
                 # in the future, time_cached should be a sibling of fields
                 $c->stash->{fields}->{time_cached} = DateTime->now()->epoch();
                 $c->set_cache($key => $c->stash->{fields});
+            } else {
+                my $resp_code = $resp->{status};
+                die "$url failed with $resp_code";
             }
         }
 
@@ -1776,7 +1779,8 @@ sub field_GET {
             $c->stash->{$field} = $cached_data;
             $c->stash->{served_from_cache} = $key;
         } else {
-            my $resp = HTTP::Tiny->new->get("$rest_server$path");
+            my $url = "$rest_server$path";
+            my $resp = HTTP::Tiny->new->get($url);
             if ($resp->{'status'} == 200 && $resp->{'content'}) {
                 $c->stash->{$field} = decode_json($resp->{'content'})->{$field};
                 $c->stash->{data_from_datomic} = 1; # widget contains data from datomic
@@ -1786,7 +1790,8 @@ sub field_GET {
                 $c->stash->{$field}->{time_cached} = DateTime->now()->epoch();
                 $c->set_cache($key => $c->stash->{$field});
             } else {
-                die "failed to load field $class::$field from datomic-to-catalyst";
+                my $resp_code = $resp->{status};
+                die "$url failed with $resp_code";
             }
         }
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -886,13 +886,13 @@ sub widget_GET {
     } elsif ($isDatomicEndpoint) {
         # Datomic workflow
 
-        my $is_recent;
-        if ($cached_data && (my $time_cached = $cached_data->{time_cached})) {
+        my $is_cache_recent;
+        if ($cached_data && (ref $cached_data eq 'HASH') && (my $time_cached = $cached_data->{time_cached})) {
             my $since_cached = DateTime->now() - DateTime->from_epoch( epoch => $time_cached);
-            $is_recent = $since_cached->in_units('hours') < 24;
+            $is_cache_recent = $since_cached->in_units('hours') < 24;
         }
 
-        if($cached_data && (ref $cached_data eq 'HASH') && $is_recent){
+        if($is_cache_recent){
             $c->stash->{fields} = $cached_data;
             # Served from cache? Let's include a link to it in the cache.
             # Primarily a debugging element.
@@ -1757,13 +1757,13 @@ sub field_GET {
     } elsif ($isDatomicEndpoint) {
         # Datomic workflow
 
-        my $is_recent;
+        my $is_cache_recent;
         if ($cached_data && (ref $cached_data eq 'HASH') && (my $time_cached = $cached_data->{time_cached})) {
             my $since_cached = DateTime->now() - DateTime->from_epoch( epoch => $time_cached);
-            $is_recent = $since_cached->in_units('hours') < 24;
+            $is_cache_recent = $since_cached->in_units('hours') < 24;
         }
 
-        if ($is_recent){
+        if ($is_cache_recent){
             $c->stash->{$field} = $cached_data;
             $c->stash->{served_from_cache} = $key;
         } else {

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -53,9 +53,7 @@ twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 
 # Delegation to an Datomic REST server.
 
-skip_ace     = 0  # 1 to skip 0 to not skip
 skip_cache   = 0  # 1 to skip 0 to not skip
-skip_datomic = 0  # 1 to skip 0 to not skip
 
 # Datomic to catayl location
 rest_server = "http://10.0.0.243:3000" # stable development instance (AWS private IP)

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -51,10 +51,6 @@ facebook_app_id      = 145770318837275
 twitter_consumer_key = dORNthy42qJmltFfBEplQ
 twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 
-# Delegation to an Datomic REST server.
-
-skip_cache   = 0  # 1 to skip 0 to not skip
-
 # Datomic to catayl location
 rest_server = "http://10.0.0.243:3000" # stable development instance (AWS private IP)
 # rest_server = "http://52.90.214.72:3000" # stable development instance (AWS public IP)


### PR DESCRIPTION
check if endpoint is available by looking up in /swagger.json on d2c (content of swagger.json is cached in memory for 5min):
- if is a d2c endpoint: use d2c workflow
    * check cache and serve if cache is < 24 hours old, otherwise call d2c endpoint and cache content with a timestamp
- if isn't a d2c endpoint: use catalyst/acedb workflow
    * check and serve cache, otherwise call catalyst API and save cache (note not timestamp related check is performed for catalyst/acedb workflow)
- if test cannot be performed (due to d2c is down or /swagger.json is down): cache only workflow
    * use cache if available (ignore timestamp) and fatal_non_compliance is Not set
