### PR TITLE
Release/259 round2

### DIFF
--- a/lib/WormBase/API/Object/Feature.pm
+++ b/lib/WormBase/API/Object/Feature.pm
@@ -230,10 +230,11 @@ sub sequence {
 
 sub dna_text {
     my ($self) = @_;
+    my $dna = $self->object->DNA_text;
 
     return {
         description => 'DNA text of the sequence feature',
-        data => $self ~~ 'DNA_text',
+        data => "$dna"
     };
 }
 

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1063,7 +1063,7 @@ sub time_since {
 sub get_rest_endpoints {
     my ($url) = @_;
 
-    if (!$endpoints{last_updated} || (time_since($endpoints{last_updated})->in_units('seconds') > 300)) {
+    if (!$endpoints{last_updated} || (time_since($endpoints{last_updated})->in_units('minutes') > 5)) {
         my @paths = _fetch_rest_endpoints($url);
         $endpoints{values} = \@paths;
         $endpoints{last_updated} = DateTime->now()->epoch();

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -17,8 +17,7 @@ use Text::MultiMarkdown 'markdown';
 use DateTime;
 use Encode;
 use HTTP::Tiny;
-use Memoize;
-use Memoize::Expire;
+
 
 
 __PACKAGE__->config(
@@ -1036,8 +1035,7 @@ sub widget_GET {
 }
 
 
-
-sub get_rest_endpoints {
+sub _fetch_rest_endpoints {
     my ($url) = @_;
 
     my $resp = HTTP::Tiny->new->get($url);
@@ -1049,9 +1047,32 @@ sub get_rest_endpoints {
     }
 }
 
-tie my %endpoints_cache => 'Memoize::Expire',  # http://perldoc.perl.org/Memoize/Expire.html
-    LIFETIME => 300;    # In seconds
-memoize 'get_rest_endpoints', SCALAR_CACHE => [HASH => \%endpoints_cache ];
+our %endpoints = (
+    last_updated => undef,
+    values => ()
+);
+
+sub time_since {
+    my ($epoch_timestamp) = @_;
+    return DateTime->now() - DateTime->from_epoch(
+        epoch => $epoch_timestamp
+    );
+}
+
+
+sub get_rest_endpoints {
+    my ($url) = @_;
+    use Data::Dumper;
+    print Dumper !$endpoints{last_updated} || time_since($endpoints{last_updated})->in_units('seconds');
+    if (!$endpoints{last_updated} || (time_since($endpoints{last_updated})->in_units('seconds') > 30)) {
+        my @paths = _fetch_rest_endpoints($url);
+        $endpoints{values} = \@paths;
+        $endpoints{last_updated} = DateTime->now()->epoch();
+    }
+
+    return @{$endpoints{values}};
+}
+
 
 sub is_slow_endpoint {
     my ($endpoint_template) = @_;

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1062,9 +1062,8 @@ sub time_since {
 
 sub get_rest_endpoints {
     my ($url) = @_;
-    use Data::Dumper;
-    print Dumper !$endpoints{last_updated} || time_since($endpoints{last_updated})->in_units('seconds');
-    if (!$endpoints{last_updated} || (time_since($endpoints{last_updated})->in_units('seconds') > 30)) {
+
+    if (!$endpoints{last_updated} || (time_since($endpoints{last_updated})->in_units('seconds') > 300)) {
         my @paths = _fetch_rest_endpoints($url);
         $endpoints{values} = \@paths;
         $endpoints{last_updated} = DateTime->now()->epoch();

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -3506,6 +3506,11 @@ div.detail-box{
   word-wrap: break-word;
 }
 
+div.detail-box .field-content ul {
+  list-style: none;
+  padding: 0;
+}
+
 div.description {
   clear:left;
   padding:0.5em 0;

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -2903,11 +2903,24 @@ div#google-map {
     width: 100%;
 }
 
-
 /* cytoscape legend */
+#cyto-wrapper {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+
+#cy-view {
+  width: 750px;
+  height: 750px;
+  margin-right: 1em;
+  z-index: 1;
+  overflow: hidden;
+}
+
+
 #cyto_legend {
     width:15em;
-    position:absolute;
     right:0;
     z-index:1001; /*
                      greater than cy div z-index 1000

--- a/root/css/main.css
+++ b/root/css/main.css
@@ -1842,7 +1842,7 @@ ul.nav-bar li .submenu {
     top: 38px;
     left: 0;
     width: 100%;
-    z-index: 1000;
+    z-index: 1500;
     padding: 24px 0;
 }
 

--- a/root/templates/classes/analysis/overview.tt2
+++ b/root/templates/classes/analysis/overview.tt2
@@ -6,7 +6,7 @@ WRAPPER highlight_box;
 
 END;
 '<div class="description">';
- fields.description.data;
+ cell_content(fields.description.data);
 '</div>';
 
 WRAPPER $field_block title="Database" key="database";
@@ -35,10 +35,11 @@ WRAPPER $field_block title="Details";
    END;
 
    WRAPPER $field_block title="Subproject" key="subproject";
-       tag2link(fields.subproject.data);
+       cell_content(fields.subproject.data);
    END;
 END;
 
+IF fields.based_on_wb_release.data || fields.based_on_db_release.data;
 WRAPPER $field_block title="Based On";
    WRAPPER $field_block title="WormBase Release" key="based_on_wb_release";
        fields.based_on_wb_release.data;
@@ -47,6 +48,7 @@ WRAPPER $field_block title="Based On";
    WRAPPER $field_block title="Database Release" key="based_on_db_release";
        fields.based_on_db_release.data;
    END;
+END;
 END;
 
 

--- a/root/templates/classes/feature/molecular_details.tt2
+++ b/root/templates/classes/feature/molecular_details.tt2
@@ -7,7 +7,7 @@ WRAPPER $field_block title='Flanking sequence' key='flanking_sequences';
 END;
 
 WRAPPER $field_block title='DNA text' key='dna_text';
-    '<div class="sequence-container">' _ fields.dna_text.data _ '</div>';
+    '<div class="sequence-container" style="word-wrap:break-word;">' _ fields.dna_text.data _ '</div>';
 END;
 
 %]

--- a/root/templates/classes/feature/overview.tt2
+++ b/root/templates/classes/feature/overview.tt2
@@ -24,10 +24,7 @@ WRAPPER highlight_box;
 END;
 
 '<div class="description">';
-WRAPPER $field_block title='' key ='description';
-   markup(fields.description.data);
-END;
-
+markup(fields.description.data);
 
 WRAPPER $field_block title='Bound by<br/> product of' key ='binds_gene_product';
      tags2link(fields.binds_gene_product.data);

--- a/root/templates/classes/gene_class/overview.tt2
+++ b/root/templates/classes/gene_class/overview.tt2
@@ -24,7 +24,9 @@ WRAPPER $field_block title="Other names" key="other_names";
 
 END;
 
-laboratory(title="Designating laboratory");
+laboratory(title="Designating laboratory",
+    passed_data=ref(fields.laboratory.data) == 'ARRAY' ? fields.laboratory.data : [fields.laboratory.data]
+);
 
 WRAPPER $field_block title="$title"||'Former Designating Laboratory' key="former_laboratory";
     untilDate = fields.former_laboratory.data.time;

--- a/root/templates/classes/transposon/overview.tt2
+++ b/root/templates/classes/transposon/overview.tt2
@@ -1,6 +1,6 @@
 <h2>[% fields.name.data.label %] <span id="fade" style="font-size:0.7em;">
 [% IF fields.member_of.data %]
-  ([% fields.member_of.data %])
+  ([% tag2link(fields.member_of.data) %])
 [% END %]
 </span></h2>
 

--- a/root/templates/classes/wbprocess/overview.tt2
+++ b/root/templates/classes/wbprocess/overview.tt2
@@ -1,11 +1,13 @@
-<h2>[% fields.name.data.label %]<span id="fade" style="font-size:0.7em;">
-[% IF fields.other_name.data %]
-  ([% fields.other_name.data %])
-[% END %]
-</span></h2>
+<h2>[% fields.name.data.label %]</h2>
 
 [%
   WRAPPER highlight_box;
+
+
+    WRAPPER $field_block title=pluralize("Other name", fields.other_name.data.size) key="other_name";
+        cell_content(fields.other_name.data);
+    END;
+
     WRAPPER $field_block title="Life stage" key="life_stage";
       cell_content( fields.life_stage.data );
     END;

--- a/root/templates/shared/fields/interaction_details.tt2
+++ b/root/templates/shared/fields/interaction_details.tt2
@@ -97,6 +97,7 @@ otherwise find them in Interaction->interaction_details %]
       <h6>Click, hold for 1 second, and drag to pan</h6>
       <h6>Use the scroll wheel to zoom</h6>
 
+      <div id="cyto-wrapper">
       <div id="cyto_legend" class="detail-box ui-corner-all">
         <p><center><h3>Legend</h3></center></p>
         [% IF TYPES.keys %]
@@ -180,14 +181,13 @@ otherwise find them in Interaction->interaction_details %]
 
 
 
-      <div id="resizable" class="ui-widget-content" style="float:left">
-
+      <div id="cy-view" class="ui-widget-content" style="float:left">
           <div id="cy" >
 
           </div>
-
       </div>
 
+      </div>
 
       <br style="clear:both"/>
 

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -1004,7 +1004,8 @@ END;
     # The Laboratory field
     # Expects the stash to contain the "laboratory" key.
     WRAPPER $field_block title="$title"||'Laboratory' key="laboratory";
-        FOREACH lab IN fields.laboratory.data;
+        labs = passed_data || fields.laboratory.data;
+        FOREACH lab IN labs;
 
             '<div style="white-space:nowrap;">';
                 tag2link(lab.laboratory);

--- a/root/templates/shared/page_elements.tt2
+++ b/root/templates/shared/page_elements.tt2
@@ -284,7 +284,7 @@ END;
     <div class="field
     [%# Add a class to disable / hide empty fields %]
     [% TRY; IF (key && (!fields.$key.defined('data')
-                        || (ref(fields.$key.data) && fields.$key.data.size == 0)))
+                        || ((ref(fields.$key.data) == 'ARRAY' || ref(fields.$key.data) == 'HASH') && fields.$key.data.size == 0)))
                 || disabled; " disabled "; END; END;%]
 
         ">
@@ -657,7 +657,8 @@ END %]
   not_empty;
   FOREACH field IN fields.keys;
     NEXT IF field == 'name';
-    IF fields.$field.defined('data') && !(ref(fields.$field.data) && fields.$field.data.size == 0);
+    NEXT IF field == 'time_cached';  # time_cached should be moved outside of fields in WS260
+    IF fields.$field.defined('data') && !((ref(fields.$field.data) == 'ARRAY' || ref(fields.$field.data) == 'HASH') && fields.$field.data.size == 0);
       not_empty = 1;
       LAST;
     END;

--- a/root/templates/shared/widgets/interactions.tt2
+++ b/root/templates/shared/widgets/interactions.tt2
@@ -22,7 +22,7 @@
 
 [% IF fields.interactions.data.edges.size> 0 %]
   [%# edges_all.size = 0, Interaction.pm has decided that there are too many edges to render with the widget %]
-  [% IF fields.interactions.data.edges_all.size > 0 %]
+  [% IF fields.interactions.data.edges_all.size <= 100 %]
       [% TYPES = fields.interactions.data.types %]
       [% NTYPES = fields.interactions.data.ntypes %]
       [% NODES = fields.interactions.data.nodes %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -54,8 +54,8 @@ twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 # Datomic to catayl location
 # rest_server = "http://10.0.0.243:3000" # stable development instance (AWS private IP)
 # rest_server = "http://52.90.214.72:3000" # stable development instance (AWS public IP)
-rest_server = "http://rest.wormbase.org" # production instance
-# rest_server = "http://datomic-to-catalyst-ws259.us-east-1.elasticbeanstalk.com" # production instance (probably over AWS public IP)
+# rest_server = "http://rest.wormbase.org" # production instance
+rest_server = "http://datomic-to-catalyst-ws259.us-east-1.elasticbeanstalk.com" # production instance (probably over AWS public IP)
 
 
 


### PR DESCRIPTION
A set of fixes for WS259:

- prepare for releasing of Overview widgets on d2c instance:
    - fix caching of d2c endpoints to expire
    - fix template of Analysis overview widget to be compatible with both new d2c json and the current json.
    - fix transposon family link in transposon overview	
    - fix text flow on sequence feature overview
- fix tt2 make topic other names work for both list and scalar
- fix long legend of cytoscape graphics covering table below
- fix tt2 to handle scalar gene class lab #5715
- fix acedb fatal non-compliance issue in Molecular details on feature #5709 
- fix tt2 error when AcePerl object is sent by API #5721 #5709 
- fix sequence feature DNA text cut off
- hide interaction figure when number of interaction (including nearby interactions) is greater than 100