### PR TITLE
(to master) WS263 round 2

### DIFF
--- a/lib/WormBase/Web.pm
+++ b/lib/WormBase/Web.pm
@@ -676,11 +676,15 @@ sub secure_uri_for {
     return $u;
 }
 
-# override 'uri_for' => sub {
-#     my ($self, @args) = @_;
-#     my $u = super(@args);
-#     return $u->path;
-#   };
+override 'uri_for' => sub {
+    # to understand override method modifier: http://search.cpan.org/dist/Moose/lib/Moose/Manual/MethodModifiers.pod
+    my ($self, @args) = @_;
+    my $u = super();
+    if($self->config->{enable_ssl}){
+        $u->scheme('https');
+    }
+    return $u;
+};
 
 # overloaded from Per_User plugin to move saved items
 sub merge_session_to_user {

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1087,6 +1087,7 @@ sub is_slow_endpoint {
         '/rest/widget/phenotype/{id}/rnai',
         '/rest/widget/phenotype/{id}/variation',
         '/rest/widget/transposon_family/{id}/var_motifs',
+        '/rest/widget/strain/{id}/contains',
         '/rest/field/gene/{id}/interaction_details',
         '/rest/field/gene/{id}/interactions'
     );

--- a/lib/WormBase/Web/Controller/Search.pm
+++ b/lib/WormBase/Web/Controller/Search.pm
@@ -332,6 +332,11 @@ sub _round_down {
 
 sub _get_url {
   my ($self, $c, $class, $id, $species, $start) = @_;
+
+  if (ref($species) eq 'HASH') {
+      $species = $species->{id};
+  }
+
   my $url;
   if($start){
     $url = $c->uri_for('/tools', 'genome', 'gbrowse', $species)->path . '?name=' . $class . ":" . $id;

--- a/root/templates/shared/widgets/interactions.tt2
+++ b/root/templates/shared/widgets/interactions.tt2
@@ -71,11 +71,11 @@
 FOREACH edge IN fields.interactions.data.edges.sort;
     IF edge.effector.class == 'gene';
     name = edge.effector.label FILTER upper;
-    "$name|";
+    "$name%7C";
     END;
     IF edge.affected.class == 'gene';
     name = edge.affected.label FILTER upper;
-    "$name|";
+    "$name%7C";
     END;
 END; %]" target="_blank">View Interaction Network in GeneMANIA</a>
 [% END %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -59,7 +59,7 @@ twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 rest_server = "http://datomic-to-catalyst-ws263.us-east-1.elasticbeanstalk.com" # production instance (probably over AWS public IP) # this value can be overriden in the wormbase_staging.conf
 
 # new search API endpoint
-search_server = "http://wormbase-search-prod.us-east-1.elasticbeanstalk.com"
+search_server = "http://wormbase-search-ws263.us-east-1.elasticbeanstalk.com"
 # max ratio of traffic to divert to new search API (the remainig will go to Xapian)
 max_ratio_elasticsearch_traffic = 0.3 # maybe overwritten in wormbase_staging.conf
 

--- a/wormbase_staging.conf
+++ b/wormbase_staging.conf
@@ -14,7 +14,7 @@
 google_api_key    = ABQIAAAAX6AZGEUlM28m4mzs0PsGkhRVfLFVmRFz44kSxZwC_XT2TLrxixTVyjZlGBxla25vFXfsh17xrvYj0g
 
 # SSL
-enable_ssl        = 0
+enable_ssl        = 1
 
 # REQUIRED FOR PRODUCTION: Base URL
 base = http://staging.wormbase.org/


### PR DESCRIPTION
- override uri_for to produce https when enable_ssl
- a bug fix for autocompletion 
- include Strain contains widget in the slow endpoint list
- update search api URL because WS263 search API in necessary for the site to work properly