### PR TITLE
(to master) HTTPS related

### DIFF
--- a/root/templates/shared/widgets/interactions.tt2
+++ b/root/templates/shared/widgets/interactions.tt2
@@ -71,11 +71,11 @@
 FOREACH edge IN fields.interactions.data.edges.sort;
     IF edge.effector.class == 'gene';
     name = edge.effector.label FILTER upper;
-    "$name|";
+    "$name%7C";
     END;
     IF edge.affected.class == 'gene';
     name = edge.affected.label FILTER upper;
-    "$name|";
+    "$name%7C";
     END;
 END; %]" target="_blank">View Interaction Network in GeneMANIA</a>
 [% END %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -59,7 +59,7 @@ twitter_consumer_secret  = ZT89nA5lmc3hGSre14dHSGCcciEPFpOWwCabaM8VUE
 rest_server = "http://datomic-to-catalyst-ws263.us-east-1.elasticbeanstalk.com" # production instance (probably over AWS public IP) # this value can be overriden in the wormbase_staging.conf
 
 # new search API endpoint
-search_server = "http://wormbase-search-prod.us-east-1.elasticbeanstalk.com"
+search_server = "http://wormbase-search-ws263.us-east-1.elasticbeanstalk.com"
 # max ratio of traffic to divert to new search API (the remainig will go to Xapian)
 max_ratio_elasticsearch_traffic = 0.3 # maybe overwritten in wormbase_staging.conf
 


### PR DESCRIPTION
- ontology browser will stop load it's own jquery and instead uses what's been loaded by Catalyst