### PR TITLE
various template changes for WS264

### DIFF
--- a/root/templates/classes/clone/sequences.tt2
+++ b/root/templates/classes/clone/sequences.tt2
@@ -26,8 +26,4 @@
                           key = 'predicted_units');
   END;
 
-  WRAPPER $field_block title="Transcripts in this region" key="transcripts";
-    tags2link(c.stash.fields.transcripts.data, '<br />', 'Results');
-  END;
-
 %]

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -1662,7 +1662,6 @@ password_reset_expires = 86400  # 24 hours
             display report
             tooltip Sequences and homologies.
             fields print_sequence
-            fields transcripts
             fields predicted_units
             fields strand
             fields sequences


### PR DESCRIPTION
- remove transcripts field in sequences widget of Clone due to redundency with predicted_units field