### PR TITLE
(to master) 267 hotfix email debug

### DIFF
--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -521,7 +521,7 @@ sub rest_register_email {
 
   $c->stash->{digest}=$url;
 
-  $c->log->debug(" send out email to $email");
+  $c->log->debug(" send out account register email to $email");
   $c->stash->{email} = {
       to       => $email,
       from     => $c->config->{register_email},
@@ -1665,7 +1665,7 @@ sub _issue_email{
     }
     $c->stash->{noboiler} = 1;
     $c->stash->{timestamp} = time();
-    $c->log->debug(" send out email to $bcc");
+    $c->log->debug(" send out helpdesk email to $bcc");
     $c->stash->{email} = {
         to => $c->config->{issue_email},
         cc => $bcc,

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1665,7 +1665,7 @@ sub _issue_email{
     }
     $c->stash->{noboiler} = 1;
     $c->stash->{timestamp} = time();
-    $c->log->debug(" send out helpdesk email to $bcc");
+    $c->log->debug(" send out helpdesk email to $bcc for issue #" . $params->{issue_number});
     $c->stash->{email} = {
         to => $c->config->{issue_email},
         cc => $bcc,


### PR DESCRIPTION
Hi @tharris 

I think the email problem is caused by single quotes in the email. This PR should hotfix the problem. Staging site already has the fix. 

I also added more debugging statements, in case there is another problem with email sending.

The single quote in the email body interferes with the single quote surrounding the JSON passed in as a command line argument. It's misread as a closing single quote that ends the JSON string. I fixed this issue by turning the single quote in the email to an html entity. 

