### PR TITLE
(to master) Fix JS bundle difference between regular prod and EB 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "@wormbase/react-scripts-for-catalyst": "1.0.9-9"
+    "@wormbase/react-scripts-for-catalyst": "1.0.9-12"
   },
   "dependencies": {
     "@geneontology/ribbon": "1.4.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -110,10 +110,10 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@wormbase/react-scripts-for-catalyst@1.0.9-9":
-  version "1.0.9-9"
-  resolved "https://registry.yarnpkg.com/@wormbase/react-scripts-for-catalyst/-/react-scripts-for-catalyst-1.0.9-9.tgz#c3b74747366d8c0e83d0e59950abe9ef00872845"
-  integrity sha1-w7dHRzZtjA6D0OWZUKvp7wCHKEU=
+"@wormbase/react-scripts-for-catalyst@1.0.9-12":
+  version "1.0.9-12"
+  resolved "https://registry.yarnpkg.com/@wormbase/react-scripts-for-catalyst/-/react-scripts-for-catalyst-1.0.9-12.tgz#e96c0a3f2ba24b025915baf0a75f1d9dc1186518"
+  integrity sha512-8Qn3q/gx9MhpDcCiUP4a20H9uMekdxR8PnH+nnlYwTWzDqCssPZfvHJGdVfnEvHCDkrjuI7cVGZjPyZxSA1TAw==
   dependencies:
     autoprefixer "7.1.1"
     babel-core "6.25.0"


### PR DESCRIPTION
Re-run the js build step `(cd client/ && yarn install --frozen-lockfile && yarn run build)` (same as before) after merging this PR should fix the problem in the file hash.

The problem was caused by a 3rd-party library (`style-loader`) inserting absolute filepaths in the bundled js. **The bundle content produced was different depending on where the source code was on the filesystem, when the bundle was built.** As a result, the regular prod site bundle, built at the jenkins workspace, were different from the EB site bundle, built at my local repo.

Here are the file hashes you will be getting:
```
  213.22 KB  build/static/js/1.07e2df48.chunk.js
  128.99 KB  build/static/js/2.aa8d3eb2.chunk.js
  113.34 KB  build/static/js/main.ecff8bf1.js
  73.65 KB   build/static/css/main.33521f2a.css
  27.19 KB   build/static/js/4.65fdc9d3.chunk.js
  19.38 KB   build/static/js/0.ea944630.chunk.js
  1.19 KB    build/static/js/3.b9ba9594.chunk.js
```