### PR TITLE
simple change: swapping JBrowse for GBrowse in "top 3" :-)

### DIFF
--- a/wormbase.conf
+++ b/wormbase.conf
@@ -978,8 +978,8 @@ password_reset_expires = 86400  # 24 hours
             <nav_item>
                 title = Top 3 most used tools
                 <nav_item>
-                    title = GBrowse
-                    url = /tools/genome/gbrowse/c_elegans_PRJNA13758/
+                    title = JBrowse
+                    url = /tools/genome/jbrowse-simple/?data=data/c_elegans_PRJNA13758
                     class = tool
                 </nav_item>
                 <nav_item>


### PR DESCRIPTION
It's silly, but the JBrowse people point this out. Given that WormBase has the largest user base in the JBrowse universe, it must be a top three at WormBase, right?