### PR TITLE
Fix intermittent failure with calling github api via HTTPS

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -30,6 +30,12 @@
       "host": {
         "sourcePath": "/var/app/current/proxy/conf.d"
       }
+    },
+    {
+      "name": "upstream-proxy-conf",
+      "host": {
+        "sourcePath": "/var/app/current/proxy/upstream-proxy/conf.d"
+      }
     }
   ],
   "containerDefinitions": [
@@ -75,7 +81,7 @@
 	  "value": "2005"
 	}
       ],
-      "links": ["acedb"],
+      "links": ["acedb", "upstream-proxy"],
       "mountPoints": [
         {
           "sourceVolume": "awseb-logs-website",
@@ -116,6 +122,29 @@
         },
         {
           "sourceVolume": "nginx-proxy-conf",
+          "containerPath": "/etc/nginx/conf.d",
+          "readOnly": true
+        }
+      ],
+      "memoryReservation": 128
+    },
+    {
+      "name": "upstream-proxy",
+      "image": "nginx:1.13.7",
+      "essential": true,
+      "portMappings": [
+        {
+          "hostPort": 3001,
+          "containerPort": 3001
+        }
+      ],
+      "mountPoints": [
+        {
+          "sourceVolume": "awseb-logs-upstream-proxy",
+          "containerPath": "/var/log/nginx"
+        },
+        {
+          "sourceVolume": "upstream-proxy-conf",
           "containerPath": "/etc/nginx/conf.d",
           "readOnly": true
         }

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "website",
-      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271",
+      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.1",
       "essential": true,
       "portMappings": [
         {

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "website",
-      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.1",
+      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.3",
       "essential": true,
       "portMappings": [
         {

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "website",
-      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS270.1",
+      "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271",
       "essential": true,
       "portMappings": [
         {

--- a/Makefile
+++ b/Makefile
@@ -184,5 +184,6 @@ production-deploy:
 # production deployment without EB, ie for bot instance
 .PHONY: production-deploy-no-eb
 production-deploy-no-eb: aws-ecr-login
+	docker-compose pull
 	docker-compose down
 	docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,13 @@ dev-start:
 		-e GOOGLE_CLIENT_SECRET=$(GOOGLE_CLIENT_SECRET) \
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		-e JWT_SECRET=$(JWT_SECRET) \
-		wormbase/website-env
+		wormbase/website-env \
+		perl ./script/wormbase_server.pl -p 5000 -r -d
+
 
 .PHONY: env-bash
 env-bash:
 	docker run -it \
-		--entrypoint /bin/bash \
 		-v ${PWD}:/usr/local/wormbase/website \
 		-v /usr/local/wormbase/website-shared-files/html:/usr/local/wormbase/website-shared-files/html \
 		-v /usr/local/wormbase/services:/usr/local/wormbase/services \
@@ -56,7 +57,9 @@ env-bash:
 		-e GOOGLE_CLIENT_SECRET=$(GOOGLE_CLIENT_SECRET) \
 		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		-e JWT_SECRET=$(JWT_SECRET) \
-		wormbase/website-env
+		wormbase/website-env \
+		/bin/bash
+
 
 .PHONY: aws-ecr-login
 aws-ecr-login:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,15 @@ Applying Hotfix on AWS ElasticBeanstalk
 	make production-deploy
 	```
 
+Production Deployment without AWS Beanstalk
+------------------------------------------
+For instances not managed by Beanstalk, deployment can be performed with:
+
+```
+# ensure port 5000 is available, then
+make production-deploy-no-eb
+```
+
 Contributing
 ------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@ services:
       - "/usr/local/wormbase/databases:/usr/local/wormbase/databases"
       - "./logs:/usr/local/wormbase/website/logs"
     restart: always
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - JWT_SECRET='${JWT_SECRET}'
   acedb:
     image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/acedb:latest
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: nginx:1.13.7
     ports:
       - "5000:80"
-    expose:
-      - "3001"
     volumes:
       - "./proxy/conf.d:/etc/nginx/conf.d"
       - "./logs/nginx:/var/log/nginx"
@@ -34,4 +32,12 @@ services:
       - "2005"
     volumes:
       - "/usr/local/wormbase/acedb/wormbase:/root/acedb/wormbase"
+    restart: always
+  upstream-proxy:
+    image: nginx:1.13.7
+    expose:
+      - "3001"
+    volumes:
+      - "./proxy/upstream-proxy/conf.d:/etc/nginx/conf.d"
+      - "./logs/upstream-proxy:/var/log/nginx"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "./logs/nginx:/var/log/nginx"
     restart: always
   website:
-    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.1
+    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.3
     expose:
       - "5000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3"
 services:
-  nginx:
+  nginx-proxy:
     image: nginx:1.13.7
     ports:
       - "5000:80"
+    expose:
+      - "3001"
     volumes:
       - "./proxy/conf.d:/etc/nginx/conf.d"
       - "./logs/nginx:/var/log/nginx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "./proxy/conf.d:/etc/nginx/conf.d"
       - "./logs/nginx:/var/log/nginx"
   website:
-    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS270.8
+    image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.1
     expose:
       - "5000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - "./proxy/conf.d:/etc/nginx/conf.d"
       - "./logs/nginx:/var/log/nginx"
+    restart: always
   website:
     image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website:WS271.1
     expose:
@@ -16,9 +17,11 @@ services:
       - "/usr/local/wormbase/services:/usr/local/wormbase/services"
       - "/usr/local/wormbase/databases:/usr/local/wormbase/databases"
       - "./logs:/usr/local/wormbase/website/logs"
+    restart: always
   acedb:
     image: 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/acedb:latest
     expose:
       - "2005"
     volumes:
       - "/usr/local/wormbase/acedb/wormbase:/root/acedb/wormbase"
+    restart: always

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website-env:1.0.1
+FROM 357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/website-env:1.0.2
 
 COPY . /usr/local/wormbase/website/
 

--- a/docker/Dockerfile.env
+++ b/docker/Dockerfile.env
@@ -73,6 +73,5 @@ ENV HOME /root
 RUN mkdir -p /usr/local/wormbase/website
 WORKDIR /usr/local/wormbase/website
 
-# Define default command.
-ENTRYPOINT ["dumb-init", "--", "./script/wormbase_server.pl"]
-CMD ["-p", "5000", "-r", "-d"]
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/bash"]

--- a/lib/WormBase/Web/Controller/REST.pm
+++ b/lib/WormBase/Web/Controller/REST.pm
@@ -1553,7 +1553,7 @@ sub _post_to_github {
     my $browser          = $params->{browser};
     my $page_url         = $params->{url};
 
-    my $github_url = "https://api.github.com/repos/" . $c->config->{github_repo} . "/issues";
+    my $github_url = $c->config->{github_api_base} . "/repos/" . $c->config->{github_repo} . "/issues";
 
   # Get a new authorization for the website repo,
   # curl -H "Content-Type: application/json"  -u "tharris" -X POST https://api.github.com/authorizations -d '{"scopes": [ "website" ],"note": "wormbase helpdesk cross-post" }'

--- a/lib/WormBase/Web/Controller/Search.pm
+++ b/lib/WormBase/Web/Controller/Search.pm
@@ -200,7 +200,7 @@ sub search_git :Path('/search/issue') :Args(2) {
     $c->stash->{type} = 'issue';
     $c->stash->{noboiler} = 1;
 
-    my $url     = "https://api.github.com/" . ($query ? "legacy/issues/search/" . $c->config->{github_repo} . "/" . ($state || 'open') . "/$query" : "repos/" . $c->config->{github_repo} . "/issues");
+    my $url     = $c->config->{github_api_base} . "/" . ($query ? "legacy/issues/search/" . $c->config->{github_repo} . "/" . ($state || 'open') . "/$query" : "repos/" . $c->config->{github_repo} . "/issues");
     $url .= "?page=" . ($page_count) . ($state && !$query ? '&state=' . $state : '');
     my $path = WormBase::Web->path_to('/') . '/credentials';
     my $token = $ENV{GITHUB_TOKEN};

--- a/proxy/conf.d/default.conf
+++ b/proxy/conf.d/default.conf
@@ -8,6 +8,14 @@ upstream caltech-forms {
     server tazendra.caltech.edu       weight=10 max_fails=2000 fail_timeout=1m;
 }
 
+server {
+  listen 3001;
+
+  location / {
+    proxy_pass https://api.github.com/;
+  }
+}
+
 
 server {
 	listen 80;

--- a/proxy/upstream-proxy/conf.d/default.conf
+++ b/proxy/upstream-proxy/conf.d/default.conf
@@ -1,0 +1,9 @@
+root /usr/share/nginx/html;
+
+server {
+  listen 3001;
+
+  location / {
+    proxy_pass https://api.github.com/;
+  }
+}

--- a/release.sh
+++ b/release.sh
@@ -28,6 +28,7 @@ sed -i -r 's/website:[^"]+/website:'"$VERSION"'/g' docker-compose.yml
 # release commit
 git diff
 git add Dockerrun.aws.json
+git add docker-compose.yml
 git commit -m "release $VERSION"
 git tag "$VERSION"
 git push origin "$VERSION"

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -94,6 +94,7 @@ using_frontend_proxy = 1
 
 # For posting issues to github -
 github_repo = "wormbase/website"
+github_api_base = "http://nginx-proxy:3001"  # go through the proxy via http, due to intermittent failure with https in starman running inside docker container
 
 # uncomment this to activate WormMine
 # Note: This will break log in functionality if WormMine is not running at this path:

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -94,7 +94,7 @@ using_frontend_proxy = 1
 
 # For posting issues to github -
 github_repo = "wormbase/website"
-github_api_base = "http://nginx-proxy:3001"  # go through the proxy via http, due to intermittent failure with https in starman running inside docker container
+github_api_base = "http://upstream-proxy:3001"  # go through the proxy via http, due to intermittent failure with https in starman running inside docker container
 
 # uncomment this to activate WormMine
 # Note: This will break log in functionality if WormMine is not running at this path:


### PR DESCRIPTION
- by proxying to "upstream-proxy" server through internal traffic via HTTP
- deploy "upstream-proxy" as additional container