### PR TITLE
273 reference and texpresso link

### DIFF
--- a/client/src/components/widgets/shared/references/index.js
+++ b/client/src/components/widgets/shared/references/index.js
@@ -17,6 +17,20 @@ import ReferenceList from './ReferenceList';
 import ReferenceItem from './ReferenceItem';
 import DownloadReference from './DownloadReference';
 
+const TEXTPRESSO_TYPE_SET = new Set([
+  'strain',
+  'gene',
+  'gariation',
+  'transgene',
+  'construct',
+  'anatomy_term',
+  'clone',
+  'life_stage',
+  'rearrangement',
+  'molecule',
+  'process',
+]);
+
 class References extends Component {
   static propTypes = {
     data: PropTypes.arrayOf(
@@ -26,6 +40,7 @@ class References extends Component {
     ).isRequired,
     pageInfo: PropTypes.shape({
       name: PropTypes.string,
+      other_names: PropTypes.arrayOf(PropTypes.string),
     }).isRequired,
     classes: PropTypes.object.isRequired,
   };
@@ -66,7 +81,8 @@ class References extends Component {
 
   render() {
     const counts = this.countsByPaperTypes(this.props.data);
-    const { classes } = this.props;
+    const { classes, pageInfo } = this.props;
+
     const data = this.filterData(this.props.data).sort(this.compareYear);
 
     const FittedListSubheader = fitComponent(ListSubheader);
@@ -138,10 +154,29 @@ class References extends Component {
           </ReferenceList>
           <DownloadReference
             data={data}
-            fileName={`${this.props.pageInfo.name}_references.csv`}
+            fileName={`${pageInfo.name}_references.csv`}
           >
             Download all references
           </DownloadReference>
+
+          {TEXTPRESSO_TYPE_SET.has(pageInfo.class) ? (
+            <section className={classes.textpressoSection}>
+              <h4>Looking for more references? </h4>
+              <p>
+                Find references identified using machine learning on{' '}
+                <a
+                  className="wb-ext"
+                  href={`https://www.textpressocentral.org/tpc/search?keyword=${[
+                    pageInfo.name,
+                    ...pageInfo.other_names,
+                  ].join(' OR ')}&scope=document&literature=C. elegans`}
+                  target="_blank"
+                >
+                  Textpresso
+                </a>
+              </p>
+            </section>
+          ) : null}
         </div>
       </div>
     );
@@ -164,7 +199,7 @@ const styles = (theme) => {
       },
     },
     sidebar: {
-      width: `calc(100% + ${4 * theme.spacing.unit}px)`,
+      width: `calc(100% + ${2 * theme.spacing.unit}px)`,
       margin: `0 ${-2 * theme.spacing.unit}px`,
       [theme.breakpoints.up('md')]: {
         width: sidebarWidth,
@@ -173,6 +208,13 @@ const styles = (theme) => {
     },
     selected: {
       backgroundColor: fade(theme.palette.text.primary, 0.12),
+    },
+    textpressoSection: {
+      margin: `${theme.spacing.unit * 5}px 0`,
+      textAlign: 'center',
+      '& p': {
+        margin: `${theme.spacing.unit}px 0`,
+      },
     },
   };
 };

--- a/client/src/components/widgets/shared/references/index.js
+++ b/client/src/components/widgets/shared/references/index.js
@@ -153,6 +153,7 @@ class References extends Component {
             }
           </ReferenceList>
           <DownloadReference
+            className={classes.downloadButton}
             data={data}
             fileName={`${pageInfo.name}_references.csv`}
           >
@@ -209,8 +210,11 @@ const styles = (theme) => {
     selected: {
       backgroundColor: fade(theme.palette.text.primary, 0.12),
     },
+    downloadButton: {
+      position: 'relative',
+      bottom: 45,
+    },
     textpressoSection: {
-      margin: `${theme.spacing.unit * 5}px 0`,
       textAlign: 'center',
       '& p': {
         margin: `${theme.spacing.unit}px 0`,

--- a/client/src/components/widgets/shared/references/index.js
+++ b/client/src/components/widgets/shared/references/index.js
@@ -72,7 +72,7 @@ class References extends Component {
   };
 
   countsByPaperTypes = (rows) => {
-    return rows.reduce((counts, row) => {
+    return (rows || []).reduce((counts, row) => {
       const ptype = row.ptype;
       counts[ptype] = counts[ptype] ? counts[ptype] + 1 : 1;
       return counts;
@@ -80,106 +80,116 @@ class References extends Component {
   };
 
   render() {
-    const counts = this.countsByPaperTypes(this.props.data);
-    const { classes, pageInfo } = this.props;
+    const { classes, pageInfo, data: dataAll = [] } = this.props;
 
-    const data = this.filterData(this.props.data).sort(this.compareYear);
+    const counts = this.countsByPaperTypes(dataAll);
+    const data = this.filterData(dataAll).sort(this.compareYear);
 
     const FittedListSubheader = fitComponent(ListSubheader);
 
     return (
-      <div className={classes.root}>
-        <div className={classes.sidebar}>
-          <List
-            dense
-            subheader={<ListSubheader>Filter by article type</ListSubheader>}
-          >
-            {Object.keys(counts)
-              .sort()
-              .map((paperType) => {
-                const isSelected =
-                  this.state.paperType && this.state.paperType === paperType;
-                // console.log(isSelected);
-                return (
-                  <ListItem
-                    button
-                    dense
-                    key={paperType}
-                    classes={{
-                      button: classNames({ [classes.selected]: isSelected }),
-                    }}
-                    onClick={() => this.handlePaperTypeUpdate(paperType)}
-                  >
-                    <ListItemText
-                      primary={paperType}
-                      secondary={counts[paperType]}
-                    />
-                    {isSelected ? (
-                      <ListItemSecondaryAction>
-                        <IconButton
-                          onClick={() => this.handlePaperTypeUpdate(paperType)}
-                          aria-label="Cancel filter"
-                        >
-                          <CancelIcon />
-                        </IconButton>
-                      </ListItemSecondaryAction>
-                    ) : null}
-                  </ListItem>
-                );
-              })}
-          </List>
-        </div>
-        <div className={classes.content}>
-          <FittedListSubheader widthOnly component="div">
-            <div>
-              {this.state.paperType ? (
-                <span>
-                  {data.length} / {this.props.data.length}{' '}
-                  {pluralize('reference', data.length)} found matching your
-                  filter
-                </span>
-              ) : (
-                <span>
-                  {data.length} {pluralize('reference', data.length)} found
-                </span>
-              )}
+      <React.Fragment>
+        {dataAll.length ? (
+          <div className={classes.root}>
+            <div className={classes.sidebar}>
+              <List
+                dense
+                subheader={
+                  <ListSubheader>Filter by article type</ListSubheader>
+                }
+              >
+                {Object.keys(counts)
+                  .sort()
+                  .map((paperType) => {
+                    const isSelected =
+                      this.state.paperType &&
+                      this.state.paperType === paperType;
+                    // console.log(isSelected);
+                    return (
+                      <ListItem
+                        button
+                        dense
+                        key={paperType}
+                        classes={{
+                          button: classNames({
+                            [classes.selected]: isSelected,
+                          }),
+                        }}
+                        onClick={() => this.handlePaperTypeUpdate(paperType)}
+                      >
+                        <ListItemText
+                          primary={paperType}
+                          secondary={counts[paperType]}
+                        />
+                        {isSelected ? (
+                          <ListItemSecondaryAction>
+                            <IconButton
+                              onClick={() =>
+                                this.handlePaperTypeUpdate(paperType)
+                              }
+                              aria-label="Cancel filter"
+                            >
+                              <CancelIcon />
+                            </IconButton>
+                          </ListItemSecondaryAction>
+                        ) : null}
+                      </ListItem>
+                    );
+                  })}
+              </List>
             </div>
-          </FittedListSubheader>
-          <ReferenceList data={data}>
-            {(pageData) =>
-              pageData.map((itemData) => (
-                <ReferenceItem key={itemData.name.id} data={itemData} />
-              ))
-            }
-          </ReferenceList>
-          <DownloadReference
-            className={classes.downloadButton}
-            data={data}
-            fileName={`${pageInfo.name}_references.csv`}
-          >
-            Download all references
-          </DownloadReference>
-
-          {TEXTPRESSO_TYPE_SET.has(pageInfo.class) ? (
-            <section className={classes.textpressoSection}>
-              <h4>Looking for more references? </h4>
-              <p>
-                Find references identified using machine learning on{' '}
-                <a
-                  className="wb-ext"
-                  href={`https://www.textpressocentral.org/tpc/search?keyword=${[
-                    pageInfo.name,
-                    ...pageInfo.other_names,
-                  ].join(' OR ')}&scope=document&literature=C. elegans`}
-                  target="_blank"
-                >
-                  Textpresso
-                </a>
-              </p>
-            </section>
-          ) : null}
-        </div>
-      </div>
+            <div className={classes.content}>
+              <FittedListSubheader widthOnly component="div">
+                <div>
+                  {this.state.paperType ? (
+                    <span>
+                      {data.length} / {this.props.data.length}{' '}
+                      {pluralize('reference', data.length)} found matching your
+                      filter
+                    </span>
+                  ) : (
+                    <span>
+                      {data.length} {pluralize('reference', data.length)} found
+                    </span>
+                  )}
+                </div>
+              </FittedListSubheader>
+              <ReferenceList data={data}>
+                {(pageData) =>
+                  pageData.map((itemData) => (
+                    <ReferenceItem key={itemData.name.id} data={itemData} />
+                  ))
+                }
+              </ReferenceList>
+              <DownloadReference
+                className={classes.downloadButton}
+                data={data}
+                fileName={`${pageInfo.name}_references.csv`}
+              >
+                Download all references
+              </DownloadReference>
+            </div>
+          </div>
+        ) : null}
+        {TEXTPRESSO_TYPE_SET.has(pageInfo.class) ? (
+          <section className={classes.textpressoSection}>
+            <h4>Looking for more references? </h4>
+            <p>
+              Find references identified using machine learning on{' '}
+              <a
+                className="wb-ext"
+                href={`https://www.textpressocentral.org/tpc/search?keyword=${[
+                  pageInfo.name,
+                  ...pageInfo.other_names,
+                ].join(' OR ')}&scope=document&literature=C. elegans`}
+                target="_blank"
+              >
+                Textpresso
+              </a>
+            </p>
+          </section>
+        ) : null}
+      </React.Fragment>
     );
   }
 }
@@ -195,6 +205,7 @@ const styles = (theme) => {
       flexDirection: 'row-reverse',
     },
     content: {
+      position: 'relative',
       [theme.breakpoints.up('md')]: {
         width: `calc(100% - ${sidebarWidth + grooveWidth}px)`,
       },
@@ -211,13 +222,14 @@ const styles = (theme) => {
       backgroundColor: fade(theme.palette.text.primary, 0.12),
     },
     downloadButton: {
-      position: 'relative',
-      bottom: 45,
+      position: 'absolute',
+      bottom: 15,
     },
     textpressoSection: {
+      margin: `${theme.spacing.unit * 2}px 0 0`,
       textAlign: 'center',
       '& p': {
-        margin: `${theme.spacing.unit}px 0`,
+        margin: `${theme.spacing.unit * 2}px 0 0`,
       },
     },
   };

--- a/client/src/components/widgets/shared/references/index.js
+++ b/client/src/components/widgets/shared/references/index.js
@@ -202,6 +202,7 @@ const styles = (theme) => {
       display: 'flex',
       flexWrap: 'wrap',
       justifyContent: 'space-between',
+      alignItems: 'baseline',
       flexDirection: 'row-reverse',
     },
     content: {

--- a/root/templates/config/external_urls
+++ b/root/templates/config/external_urls
@@ -972,6 +972,13 @@
 	search      = 'http://www.expasy.org/uniprot/%s'
 	}
 
+ Textpresso = {
+	description = 'Knowledge discovery through full text mining, classification and searching'
+	base        = 'https://textpressocentral.org/'
+	search      = 'https://www.textpressocentral.org/tpc/search?keyword=%s&scope=document&literature=C. elegans'
+	}
+
+
  TheAmericanSocietyForBiochemistryandMolecularBiology = {
 	description = 'The American Society For Biochemistry and Molecular Biology'
 	base        = 'http://www.asbmb.org/'

--- a/root/templates/header/default.tt2
+++ b/root/templates/header/default.tt2
@@ -25,6 +25,7 @@
 [% save = object.name.data.class.match('paper') ? 'my_library' : 'reports'%]
 [% wbid = get_star_id(object.name.data.id || c.req.path) %]
 [% label = label.remove('[\'"]') %]
+[% other_names = object.name.data.other_names %]
 
 <!-- START: Revised header region -->
 <div id="header" class="clearfix" data-page='{
@@ -32,6 +33,12 @@
     "wbid": "[% wbid || class %]",
     "name": "[% label | uri %]",
     "id" : "[% object.name.data.id | uri %]",
+    "other_names" : [
+        [% FOREACH n IN other_names;
+             "\"$n\"";
+	     ',' IF !loop.last;
+        END; %]
+    ],
     "class" : "[% object.name.data.class FILTER lower %]",
     "type" : "[% c.stash.section | uri %]",
     "is_obj": "[% is_obj %]",

--- a/root/templates/shared/widgets/references.tt2
+++ b/root/templates/shared/widgets/references.tt2
@@ -1,5 +1,5 @@
 [% element_id = "references-field" %]
 <div id="[%- element_id -%]"></div>
 <script>
-  WB.renderWidget([%- json_encode(fields.references.data.results || {}) -%], "[%- element_id -%]", "references");
+  WB.renderWidget([%- json_encode(fields.references.data.results || []) -%], "[%- element_id -%]", "references");
 </script>

--- a/wormbase.conf
+++ b/wormbase.conf
@@ -1470,6 +1470,13 @@ password_reset_expires = 86400  # 24 hours
             display report
             fields name
         </ontology_browser>
+        <references>
+            name  references
+            title References
+            display report
+            tooltip Publications that describe the creation or use of this anatomy term.
+            fields references
+        </references>
     </widgets>
         <tools>
         </tools>


### PR DESCRIPTION
Relates to #7347 

- Add linkout to Textpresso from references widget in a set of pages
- Construct search keywords from entity synonyms from `data-page` in `#header` (based on other_names in WB search index documents)
- Bug fixes for references widget display
