### PR TITLE
remove or encode untrusted query parameter

### DIFF
--- a/root/templates/feed/issue.tt2
+++ b/root/templates/feed/issue.tt2
@@ -1,6 +1,6 @@
 [%# load defined blocks and variable in
   # shared/report_issue.tt2%]
-[% msg=c.request.param('msg') %]
+[% msg=c.request.param('msg') | html %]
 [% PROCESS shared/report_issue.tt2 %]
 
 [%# override variables %]

--- a/root/templates/header/default.tt2
+++ b/root/templates/header/default.tt2
@@ -37,16 +37,6 @@
     "is_obj": "[% is_obj %]",
     "save": "[% save %]",
     "history": "[% c.user_session.history_on ? '1' : '0' %]"
-    [%  param_from_uri = c.request.param('from') FILTER html;
-        param_query = c.request.param('query') FILTER html;
-        IF (param_query || param_from_uri );
-            IF (param_from_uri.match('^(?i)http'));  # case insensitive match for 'http' at start of a uri
-                ', "notify": "redirected from external site"';
-            ELSE;
-                ', "notify": "redirected from ' _ param_from_uri _ ' ' _ param_query _ '"';
-            END;
-        END;
-    %]
 }'>
 
   <div class="status-bar"></div>

--- a/root/templates/shared/sidebar_structure.tt2
+++ b/root/templates/shared/sidebar_structure.tt2
@@ -73,13 +73,6 @@
       [%  '<span id="breadcrumbs">' _ breadcrumbs_string _ '</span>'; %]
       <h2>
           [% title %]
-    [% IF c.request.param('from');
-        from_uri = c.request.param('from');
-        UNLESS (from_uri.match('^(?i)http'));  # case insensitive match for 'http' at start of a uri, Not display these external redirects
-            '<span class="note">(redirected from <a href="' _ c.uri_for(from_uri, {redirect=>'no'}) _ '">' _ from_uri _ '</a>)</span>';
-        END;
-    END; %]
-
       </h2>
 
       </div>


### PR DESCRIPTION
Avoid embedding link based on the `from` url query.