### PR TITLE
more green-ish blue and more yellow-ish orange for color-blindness

### DIFF
--- a/client/src/components/InteractionGraph/InteractionGraph.js
+++ b/client/src/components/InteractionGraph/InteractionGraph.js
@@ -400,9 +400,9 @@ class InteractionGraph extends Component {
 
   getEdgeColor = (type) => {
     const colorScheme = [
-      '#33a02c', //"#0A6314",  // green
+      '#009e73', //"#0A6314",  // green
       '#6a3d9a', //"#69088A",  // dark purple
-      '#ff7f00', //"#FF8000",  // orange
+      '#ffce3b', //"#FF8000",  // orange
       '#1f78b4', //"#08298A",  // blue
       '#00E300', // bright green
       '#05C1F0', // light blue

--- a/client/src/components/InteractorVennDiagram/index.js
+++ b/client/src/components/InteractorVennDiagram/index.js
@@ -44,9 +44,9 @@ function InteractorVennDiagram({ data: dataRaw = [], classes = {} }) {
       .filter((d) => d.sets.length === 1)
       .reduce((result, d) => {
         const colors = {
-          'Physical interactor': '#33a02c',
+          'Physical interactor': '#009e73',
           'Genetic interactor': '#6a3d9a',
-          'Regulatory interactor': '#ff7f00',
+          'Regulatory interactor': '#ffce3b',
         };
         result[d.sets] = colors[d.sets[0]];
         return result;


### PR DESCRIPTION
@WBjae @chris-grove I heard your concern for the colour choice of the Venn diagram with respect to color blindness. I modified the color, to make the green more blue-ish, and the orange more yellow-ish.

Attached blow screenshots of the simulated color blindness view of the modified venn diagram.

The same color change is made to the network drawing.

![Screen Shot 2019-12-05 at 4 01 43 PM](https://user-images.githubusercontent.com/1753893/70274561-5e136600-177a-11ea-9faa-19d4c964569d.png)
![Screen Shot 2019-12-05 at 4 01 54 PM](https://user-images.githubusercontent.com/1753893/70274562-5e136600-177a-11ea-8e78-fc333c8a4af9.png)
![Screen Shot 2019-12-05 at 4 02 08 PM](https://user-images.githubusercontent.com/1753893/70274564-5e136600-177a-11ea-8570-61918bf9353c.png)
![Screen Shot 2019-12-05 at 4 02 52 PM](https://user-images.githubusercontent.com/1753893/70274566-5eabfc80-177a-11ea-9cc5-d903ac60b591.png)



