### PR TITLE
retire treefam preview from homology widget

### DIFF
--- a/root/templates/classes/gene/homology.tt2
+++ b/root/templates/classes/gene/homology.tt2
@@ -43,14 +43,9 @@
 
 
    WRAPPER $field_block title="TreeFam" key="treefam";
-       USE url= format(site.external_urls.TREEFAM.image);
        FOREACH obj IN fields.treefam.data.unique;
-          '<h4>Treefam (ID:' _ external_link('treefam', obj, obj) _  ')</h4>';
-          WRAPPER toggle title="View image" open=1;
-              '<iframe width="750" height="800" name="treefam" src=' _ url(obj,obj) _ ' width="700" height="500" scrolling="auto"></iframe>';
-          END;
-        END;
-        '<br /><p>Phylogenetic trees provided by the' _ text2link('treefam','','Treefam') _ ' project.</p>';
+          external_link('treefam', obj, obj);
+       END;
    END;
 
 %]

--- a/root/templates/config/external_urls
+++ b/root/templates/config/external_urls
@@ -1036,7 +1036,7 @@
 	description = 'TreeFam (Tree families database) is a database of phylogenetic trees of animal genes. It aims at developing a curated resource that gives reliable information about ortholog and paralog assignments, and evolutionary history of various gene families.'
 	maintainer  = ''
 	base        = 'http://www.treefam.org/'
-	search      = 'http://www.treefam.org/family/%s'
+	search      = 'http://www.treefam.org/family/%s#tabview=tab1'
 	image       = 'http://www.treefam.org/viewtree/%s'
 	#image       = 'http://legacy.treefam.org/cgi-bin/treeview.pl?pic&ac=%s&stype=clean&highlight=%s'
 	}


### PR DESCRIPTION
Unfortunately the treefam preview has to be removed from the gene homology widget, because it no longer works. 

The treefam preview showed a phylogenetic tree, domain cartoon of the homologs, and links to pfam domains. If anyone knows of alternative tools serving similar functions, please let me know.

Treefam's use of HTTP (instead of the more secure and universal HTTPS) prevents the loading of the preview on WormBase site as an iframe, because modern browsers won't load it, treating it as not secure.

The Treefam site seems to have been unmaintained for a while. My attempted workarounds, such as using a proxy, didn't work either, because the AJAX calls to treefam.org is prevented by browser's single origin policy. 